### PR TITLE
🌋 Vulkan backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ elseif (BX_GRAPHICS_BACKEND STREQUAL "Vulkan")
 		"src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ elseif (BX_GRAPHICS_BACKEND STREQUAL "Vulkan")
 		"src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/compute_pipeline.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp"
 		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,30 @@ if (BX_GRAPHICS_BACKEND STREQUAL "OpenGL")
 
 elseif (BX_GRAPHICS_BACKEND STREQUAL "Vulkan")
 	set (BX_SRCS ${BX_SRCS}
+		"src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/device.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/extensions.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/fence.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/image.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/instance.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/pfn.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/physical_device.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/sampler.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/semaphore.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/shader.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/spirv_compiler.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp"
+		"src/bx/engine/modules/graphics/backend/vulkan/validation.cpp"
+
 		"src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp"
 	)
 

--- a/include/bx/engine/containers/optional.hpp
+++ b/include/bx/engine/containers/optional.hpp
@@ -49,6 +49,12 @@ public:
 		delete data;
 	}
 
+	void Reset()
+	{
+		delete data;
+		data = nullptr;
+	}
+		
 	template <typename ...Params>
 	static Optional<T> Some(Params&&... params)
 	{

--- a/include/bx/engine/containers/optional.hpp
+++ b/include/bx/engine/containers/optional.hpp
@@ -82,6 +82,19 @@ public:
 		return *data;
 	}
 
+	b8 operator==(const Optional<T>& other) const
+	{
+		if (IsNone())
+			return other.IsNone();
+
+		return *data == *other.data;
+	}
+
+	b8 operator!=(const Optional<T>& other) const
+	{
+		return !(*this == other);
+	}
+
 private:
 	template <typename ...Params>
 	Optional(Params&&... params)

--- a/include/bx/engine/core/ecs.hpp
+++ b/include/bx/engine/core/ecs.hpp
@@ -29,7 +29,7 @@
 #define ECS_MAX_COMPONENTS 64
 #endif
 
-using EntityId = UUID;
+using EntityId = Uuid;
 constexpr EntityId INVALID_ENTITY_ID = 0;
 
 class Entity;
@@ -423,7 +423,7 @@ public:
     /// <returns>New valid entity.</returns>
     static Entity CreateEntity()
     {
-        return CreateEntityWithId(GenUUID::MakeUUID());
+        return CreateEntityWithId(GenUuid::MakeUuid());
     }
 
     /// <summary>

--- a/include/bx/engine/core/ecs.hpp
+++ b/include/bx/engine/core/ecs.hpp
@@ -29,7 +29,7 @@
 #define ECS_MAX_COMPONENTS 64
 #endif
 
-using EntityId = Uuid;
+using EntityId = BX::UUID;
 constexpr EntityId INVALID_ENTITY_ID = 0;
 
 class Entity;
@@ -423,7 +423,7 @@ public:
     /// <returns>New valid entity.</returns>
     static Entity CreateEntity()
     {
-        return CreateEntityWithId(GenUuid::MakeUuid());
+        return CreateEntityWithId(BX::GenUuid::MakeUuid());
     }
 
     /// <summary>

--- a/include/bx/engine/core/hash.hpp
+++ b/include/bx/engine/core/hash.hpp
@@ -2,13 +2,6 @@
 
 #include "bx/engine/core/type.hpp"
 
-template <class T>
-inline void hashCombine(SizeType& s, const T& v)
-{
-    Hash<T> h;
-    s^= h(v) + 0x9e3779b9 + (s<< 6) + (s>> 2);
-}
-
 #ifndef MEMORY_CUSTOM_CONTAINERS
 
 #include <functional>
@@ -67,3 +60,10 @@ struct Hash<String>
 };
 
 #endif
+
+template <typename T>
+inline void hashCombine(SizeType& s, const T& v)
+{
+	Hash<T> h;
+	s ^= h(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
+}

--- a/include/bx/engine/core/hash.hpp
+++ b/include/bx/engine/core/hash.hpp
@@ -5,7 +5,6 @@
 #ifndef MEMORY_CUSTOM_CONTAINERS
 
 #include <functional>
-#include <xhash>
 
 template <typename T>
 using Hash = std::hash<T>;

--- a/include/bx/engine/core/hash.hpp
+++ b/include/bx/engine/core/hash.hpp
@@ -1,5 +1,14 @@
 #pragma once
 
+#include "bx/engine/core/type.hpp"
+
+template <class T>
+inline void hashCombine(SizeType& s, const T& v)
+{
+    Hash<T> h;
+    s^= h(v) + 0x9e3779b9 + (s<< 6) + (s>> 2);
+}
+
 #ifndef MEMORY_CUSTOM_CONTAINERS
 
 #include <functional>

--- a/include/bx/engine/core/hash.hpp
+++ b/include/bx/engine/core/hash.hpp
@@ -5,6 +5,7 @@
 #ifndef MEMORY_CUSTOM_CONTAINERS
 
 #include <functional>
+#include <xhash>
 
 template <typename T>
 using Hash = std::hash<T>;

--- a/include/bx/engine/core/resource.hpp
+++ b/include/bx/engine/core/resource.hpp
@@ -383,5 +383,5 @@ private:
 
 private:
 	ResourceHandle m_handle = RESOURCE_HANDLE_INVALID;
-	UUID m_uuid;
+	Uuid m_uuid;
 };

--- a/include/bx/engine/core/resource.hpp
+++ b/include/bx/engine/core/resource.hpp
@@ -383,5 +383,5 @@ private:
 
 private:
 	ResourceHandle m_handle = RESOURCE_HANDLE_INVALID;
-	Uuid m_uuid;
+	BX::UUID m_uuid;
 };

--- a/include/bx/engine/core/type.hpp
+++ b/include/bx/engine/core/type.hpp
@@ -20,7 +20,7 @@ private:
 
 	static TypeId Id()
 	{
-		static Hash<String> hashFn;
+		static std::hash<String> hashFn;
 		static const TypeId id = hashFn(ClassName());
 		return id;
 	}

--- a/include/bx/engine/core/uuid.hpp
+++ b/include/bx/engine/core/uuid.hpp
@@ -2,10 +2,10 @@
 
 #include "bx/engine/core/byte_types.hpp"
 
-using UUID = u64;
+using Uuid = u64;
 
-class GenUUID
+class GenUuid
 {
 public:
-	static UUID MakeUUID();
+	static Uuid MakeUuid();
 };

--- a/include/bx/engine/core/uuid.hpp
+++ b/include/bx/engine/core/uuid.hpp
@@ -2,10 +2,13 @@
 
 #include "bx/engine/core/byte_types.hpp"
 
-using Uuid = u64;
-
-class GenUuid
+namespace BX
 {
-public:
-	static Uuid MakeUuid();
-};
+	using UUID = u64;
+	
+	class GenUuid
+	{
+	public:
+		static UUID MakeUuid();
+	};
+}

--- a/include/bx/engine/modules/graphics.hpp
+++ b/include/bx/engine/modules/graphics.hpp
@@ -72,6 +72,7 @@ public:
 	static void DispatchWorkgroups(u32 x, u32 y, u32 z);
 	static void EndComputePass(ComputePassHandle& computePass);
 
+	// TODO: merge these two, make SizeType optional??
 	static void WriteBuffer(BufferHandle buffer, u64 offset, const void* data);
 	static void WriteBuffer(BufferHandle buffer, u64 offset, const void* data, SizeType size);
 

--- a/include/bx/engine/modules/graphics/backend/graphics_vulkan.hpp
+++ b/include/bx/engine/modules/graphics/backend/graphics_vulkan.hpp
@@ -14,6 +14,7 @@ class GraphicsVulkan
 public:
     static ImGui_ImplVulkan_InitInfo ImGuiInitInfo();
     static std::shared_ptr<Vk::DescriptorSet> TextureAsDescriptorSet(TextureHandle texture);
+    static u32 GetCurrentFrameIdx();
 
     static VkCommandBuffer RawCommandBuffer();
     static void WaitIdle();

--- a/include/bx/engine/modules/graphics/backend/graphics_vulkan.hpp
+++ b/include/bx/engine/modules/graphics/backend/graphics_vulkan.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "bx/engine/modules/graphics.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp"
 
 #include "vulkan/vulkan_api.hpp"
+
+#include <memory>
 
 struct ImGui_ImplVulkan_InitInfo;
 
@@ -10,6 +13,7 @@ class GraphicsVulkan
 {
 public:
     static ImGui_ImplVulkan_InitInfo ImGuiInitInfo();
+    static std::shared_ptr<Vk::DescriptorSet> TextureAsDescriptorSet(TextureHandle texture);
 
     static VkCommandBuffer RawCommandBuffer();
     static void WaitIdle();

--- a/include/bx/engine/modules/graphics/backend/vulkan/Instance.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/Instance.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	class Instance : NoCopy
+	{
+	public:
+		Instance(void* window, bool debug);
+		~Instance();
+
+		VkInstance GetInstance() const;
+		VkSurfaceKHR GetSurface() const;
+
+	private:
+		VkSurfaceKHR CreateSurface(void* window, VkInstance instance);
+
+		VkDebugReportCallbackEXT debugReportCallback;
+		VkInstance instance;
+		VkSurfaceKHR surface;
+	};
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/buffer.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/buffer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	class Device;
+	class PhysicalDevice;
+
+    enum class BufferLocation { GPU_ONLY, CPU_TO_GPU };
+
+    class Buffer : NoCopy {
+    public:
+        Buffer(const String& name, std::shared_ptr<Device> device,
+            const PhysicalDevice& physicalDevice, VkBufferUsageFlags usage, uint64_t size,
+            BufferLocation location);
+        ~Buffer();
+        explicit Buffer(Buffer&& other) noexcept;
+        Buffer& operator=(Buffer&& other) noexcept;
+
+        void* Map();
+        void Unmap();
+
+        uint64_t Size() const;
+        VkBuffer GetBuffer() const;
+        VkDeviceAddress GetDeviceAddress() const;
+
+    private:
+        uint64_t size;
+        VkBuffer buffer;
+        VmaAllocation allocation;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -38,7 +38,7 @@ namespace Vk
         void SetViewport(const Rect2D& rect2D, bool normalize = true);
 
         void BindVertexBuffer(std::shared_ptr<Buffer> vertexBuffer);
-        void BindIndexBuffer(std::shared_ptr<Buffer> indexBuffer);
+        void BindIndexBuffer(std::shared_ptr<Buffer> indexBuffer, VkIndexType type);
 
         /*void BuildBLAS(VkAccelerationStructureGeometryKHR geometry,
             std::shared_ptr<Buffer> scratchBuffer, std::shared_ptr<Buffer> resultBuffer,

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -26,6 +26,7 @@ namespace Vk
 
         void CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Buffer> dst);
         void CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Image> dst);
+        void CopyBuffers(std::shared_ptr<Image> src, std::shared_ptr<Buffer> dst, VkOffset3D offset, VkExtent3D size);
         void CopyImages(std::shared_ptr<Image> src, std::shared_ptr<Image> dst);
         void CopyImagesIntoCubemap(const std::array<std::shared_ptr<Image>, 6>& images,
             std::shared_ptr<Image> cubemap);

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -31,8 +31,7 @@ namespace Vk
             std::shared_ptr<Image> cubemap);
         void GenerateMips(std::shared_ptr<Image> image);
 
-        void TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout,
-            VkAccessFlags access, VkPipelineStageFlags pipelineStage);
+        void TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout, VkPipelineStageFlags pipelineStage);
 
         void SetScissor(const Rect2D& rect2D);
         void SetViewport(const Rect2D& rect2D, bool normalize = true);

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -65,6 +65,8 @@ namespace Vk
             this->PushConstant(name, static_cast<void*>(&constant), sizeof(T), stageFlags);
         }
 
+        void TrackDescriptorSet(std::shared_ptr<DescriptorSet> descriptorSet);
+
     private:
         friend class CmdQueue;
         CmdList(std::shared_ptr<Device> device, const CmdQueue& cmdQueue);

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -32,7 +32,7 @@ namespace Vk
         void GenerateMips(std::shared_ptr<Image> image);
 
         void TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout,
-            VkAccessFlags access, VkShaderStageFlags pipelineStage);
+            VkAccessFlags access, VkPipelineStageFlags pipelineStage);
 
         void SetScissor(const Rect2D& rect2D);
         void SetViewport(const Rect2D& rect2D, bool normalize = true);
@@ -44,7 +44,7 @@ namespace Vk
             std::shared_ptr<Buffer> scratchBuffer, std::shared_ptr<Buffer> resultBuffer,
             VkAccelerationStructureKHR blas, uint32_t indexCount);*/
 
-        void BeginRenderPass(std::shared_ptr<RenderPass> renderPass, const Framebuffer& framebuffer,
+        void BeginRenderPass(std::shared_ptr<RenderPass> renderPass, std::shared_ptr<Framebuffer> framebuffer,
             const Color& clearColor);
         void EndRenderPass();
 
@@ -87,6 +87,7 @@ namespace Vk
         std::vector<std::shared_ptr<RenderPass>> trackedRenderPasses;
         std::vector<std::shared_ptr<Buffer>> trackedBuffers;
         std::vector<std::shared_ptr<Image>> trackedImages;
+        std::vector<std::shared_ptr<Framebuffer>> trackedFramebuffers;
         std::vector<std::shared_ptr<DescriptorSet>> trackedDescriptorSets;
     };
 }

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -13,6 +13,7 @@ namespace Vk
     class Buffer;
     class Image;
     class GraphicsPipeline;
+    class ComputePipeline;
     struct Rect2D;
     class Framebuffer;
     class RenderPass;
@@ -52,7 +53,7 @@ namespace Vk
             VkPipelineBindPoint pipelineType = VK_PIPELINE_BIND_POINT_GRAPHICS);
 
         void BindGraphicsPipeline(std::shared_ptr<GraphicsPipeline> graphicsPipeline);
-        //void BindComputePipeline(std::shared_ptr<ComputePipeline> computePipeline);
+        void BindComputePipeline(std::shared_ptr<ComputePipeline> computePipeline);
 
         void Draw(uint32_t vertexCount, uint32_t instanceCount = 1, uint32_t firstVertex = 0,
             uint32_t firstInstance = 0);
@@ -65,8 +66,6 @@ namespace Vk
         void PushConstant(const std::string& name, T& constant, VkShaderStageFlags stageFlags) {
             this->PushConstant(name, static_cast<void*>(&constant), sizeof(T), stageFlags);
         }
-
-        void TrackDescriptorSet(std::shared_ptr<DescriptorSet> descriptorSet);
 
     private:
         friend class CmdQueue;
@@ -85,7 +84,7 @@ namespace Vk
             VkShaderStageFlags stageFlags);
 
         std::shared_ptr<GraphicsPipeline> boundGraphicsPipeline;
-        //std::shared_ptr<ComputePipeline> boundComputePipeline;
+        std::shared_ptr<ComputePipeline> boundComputePipeline;
         std::vector<std::shared_ptr<RenderPass>> trackedRenderPasses;
         std::vector<std::shared_ptr<Buffer>> trackedBuffers;
         std::vector<std::shared_ptr<Image>> trackedImages;

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/core/math.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class CmdQueue;
+    class Device;
+    class Buffer;
+    class Image;
+    class GraphicsPipeline;
+    struct Rect2D;
+    class Framebuffer;
+    class RenderPass;
+    class DescriptorSet;
+
+    class CmdList : NoCopy {
+    public:
+        ~CmdList();
+
+        VkCommandBuffer GetCommandBuffer() const;
+
+        void CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Buffer> dst);
+        void CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Image> dst);
+        void CopyImages(std::shared_ptr<Image> src, std::shared_ptr<Image> dst);
+        void CopyImagesIntoCubemap(const std::array<std::shared_ptr<Image>, 6>& images,
+            std::shared_ptr<Image> cubemap);
+        void GenerateMips(std::shared_ptr<Image> image);
+
+        void TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout,
+            VkAccessFlags access, VkShaderStageFlags pipelineStage);
+
+        void SetScissor(const Rect2D& rect2D);
+        void SetViewport(const Rect2D& rect2D, bool normalize = true);
+
+        void BindVertexBuffer(std::shared_ptr<Buffer> vertexBuffer);
+        void BindIndexBuffer(std::shared_ptr<Buffer> indexBuffer);
+
+        /*void BuildBLAS(VkAccelerationStructureGeometryKHR geometry,
+            std::shared_ptr<Buffer> scratchBuffer, std::shared_ptr<Buffer> resultBuffer,
+            VkAccelerationStructureKHR blas, uint32_t indexCount);*/
+
+        void BeginRenderPass(std::shared_ptr<RenderPass> renderPass, const Framebuffer& framebuffer,
+            const Color& clearColor);
+        void EndRenderPass();
+
+        void BindDescriptorSet(std::shared_ptr<DescriptorSet> descriptorSet, uint32_t set,
+            VkPipelineBindPoint pipelineType = VK_PIPELINE_BIND_POINT_GRAPHICS);
+
+        void BindGraphicsPipeline(std::shared_ptr<GraphicsPipeline> graphicsPipeline);
+        //void BindComputePipeline(std::shared_ptr<ComputePipeline> computePipeline);
+
+        void Draw(uint32_t vertexCount, uint32_t instanceCount = 1, uint32_t firstVertex = 0,
+            uint32_t firstInstance = 0);
+        void DrawElements(uint32_t indexCount, uint32_t instanceCount = 1, uint32_t firstIndex = 0,
+            uint32_t firstInstance = 0, uint32_t vertexOffset = 0);
+
+        void Dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1);
+
+        template <typename T>
+        void PushConstant(const std::string& name, T& constant, VkShaderStageFlags stageFlags) {
+            this->PushConstant(name, static_cast<void*>(&constant), sizeof(T), stageFlags);
+        }
+
+    private:
+        friend class CmdQueue;
+        CmdList(std::shared_ptr<Device> device, const CmdQueue& cmdQueue);
+
+        const std::shared_ptr<Device> device;
+        const CmdQueue& cmdQueue;
+
+        VkCommandBuffer cmdBuffer;
+
+        void Begin();
+        void End();
+        void Reset();
+
+        void PushConstant(const std::string& name, void* constant, size_t size,
+            VkShaderStageFlags stageFlags);
+
+        std::shared_ptr<GraphicsPipeline> boundGraphicsPipeline;
+        //std::shared_ptr<ComputePipeline> boundComputePipeline;
+        std::vector<std::shared_ptr<RenderPass>> trackedRenderPasses;
+        std::vector<std::shared_ptr<Buffer>> trackedBuffers;
+        std::vector<std::shared_ptr<Image>> trackedImages;
+        std::vector<std::shared_ptr<DescriptorSet>> trackedDescriptorSets;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/list.hpp"
+
+#include "vulkan_api.hpp"
+
+#include <queue>
+
+namespace Vk
+{
+    class Device;
+    class PhysicalDevice;
+    class CmdList;
+    class Semaphore;
+    class Fence;
+
+    enum class QueueType { GRAPHICS, COMPUTE, PRESENT };
+
+    class CmdQueue : NoCopy {
+    public:
+        CmdQueue(const std::shared_ptr<Device> device, const PhysicalDevice& physicalDevice,
+            QueueType type);
+        ~CmdQueue();
+
+        void ProcessCmdLists(bool wait = false);
+        std::shared_ptr<CmdList> GetCmdList();
+        void SubmitCmdList(std::shared_ptr<CmdList> cmdList, std::shared_ptr<Fence> fence,
+            const List<Semaphore*>& waitSemaphores,
+            const List<VkPipelineStageFlags>& waitStages,
+            const List<Semaphore*>& signalSemaphores);
+
+        VkQueue GetQueue() const;
+        VkCommandPool GetCmdPool() const;
+
+    private:
+        VkQueue queue;
+        VkCommandPool cmdPool;
+
+        const std::shared_ptr<Device> device;
+
+        struct InFlightCmdList {
+            std::shared_ptr<Fence> fence;
+            std::shared_ptr<CmdList> cmdList;
+        };
+
+        std::queue<InFlightCmdList> busyCmdLists;
+        std::queue<std::shared_ptr<CmdList>> idleCmdLists;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/compute_pipeline.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/compute_pipeline.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/list.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+    class DescriptorSetLayout;
+    class Shader;
+
+    class ComputePipeline : NoCopy {
+    public:
+        ComputePipeline(
+            std::shared_ptr<Device> device, std::shared_ptr<Shader> shader,
+            List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts);
+        ~ComputePipeline();
+
+        VkPipeline GetPipeline() const;
+        VkPipelineLayout GetLayout() const;
+
+    private:
+        const std::shared_ptr<Device> device;
+        const List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts;
+
+        VkPipelineLayout pipelineLayout;
+        VkPipeline pipeline;
+    };
+}  // namespace Vk

--- a/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+#include "bx/engine/modules/graphics/type.hpp"
+
+namespace Vk
+{
+	VkBufferUsageFlags BufferUsageFlagsToVk(BufferUsageFlags usage);
+	VkImageUsageFlags TextureUsageFlagsToVk(TextureUsageFlags usage, b8 depthFormat);
+	VkFormat TextureFormatToVk(TextureFormat format);
+	VkImageType TextureDimensionToVk(TextureDimension dimension);
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
@@ -15,4 +15,5 @@ namespace Vk
 	VkShaderStageFlagBits ShaderTypeToVk(ShaderType type);
 	VkDescriptorType BindingTypeToVk(BindingType type);
 	VkShaderStageFlags ShaderStageFlagsToVk(ShaderStageFlags stageFlags);
+	VkFormat VertexFormatToVk(const VertexFormat& format);
 }

--- a/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
@@ -11,6 +11,7 @@ namespace Vk
 	VkBufferUsageFlags BufferUsageFlagsToVk(BufferUsageFlags usage);
 	VkImageUsageFlags TextureUsageFlagsToVk(TextureUsageFlags usage, b8 depthFormat);
 	VkFormat TextureFormatToVk(TextureFormat format);
+	VkImageLayout TextureFormatToVkImageLayout(TextureFormat format);
 	VkImageType TextureDimensionToVk(TextureDimension dimension);
 	VkShaderStageFlagBits ShaderTypeToVk(ShaderType type);
 	VkDescriptorType BindingTypeToVk(BindingType type);

--- a/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
@@ -12,4 +12,5 @@ namespace Vk
 	VkImageUsageFlags TextureUsageFlagsToVk(TextureUsageFlags usage, b8 depthFormat);
 	VkFormat TextureFormatToVk(TextureFormat format);
 	VkImageType TextureDimensionToVk(TextureDimension dimension);
+	VkShaderStageFlagBits ShaderTypeToVk(ShaderType type);
 }

--- a/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/conversion.hpp
@@ -13,4 +13,6 @@ namespace Vk
 	VkFormat TextureFormatToVk(TextureFormat format);
 	VkImageType TextureDimensionToVk(TextureDimension dimension);
 	VkShaderStageFlagBits ShaderTypeToVk(ShaderType type);
+	VkDescriptorType BindingTypeToVk(BindingType type);
+	VkShaderStageFlags ShaderStageFlagsToVk(ShaderStageFlags stageFlags);
 }

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+
+    class DescriptorPool : NoCopy {
+    public:
+        DescriptorPool(const std::shared_ptr<Device> device);
+        ~DescriptorPool();
+
+        VkDescriptorPool GetPool() const;
+
+    private:
+        VkDescriptorPool pool;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+    class DescriptorPool;
+    class DescriptorSetLayout;
+    class Buffer;
+    class Image;
+    class Sampler;
+
+    class DescriptorSet : NoCopy {
+    public:
+        DescriptorSet(const String& name, const std::shared_ptr<Device> device,
+            const std::shared_ptr<DescriptorPool> pool,
+            const std::shared_ptr<DescriptorSetLayout> layout);
+        ~DescriptorSet();
+
+        void SetBuffer(uint32_t binding, VkDescriptorType type, std::shared_ptr<Buffer> buffer);
+        void SetImage(uint32_t binding, VkDescriptorType type, std::shared_ptr<Image> image,
+            std::shared_ptr<Sampler> sampler);
+
+        VkDescriptorSet GetDescriptorSet() const;
+
+    private:
+        VkDescriptorSet descriptorSet;
+
+        const std::shared_ptr<Device> device;
+        const std::shared_ptr<DescriptorPool> pool;
+        const std::shared_ptr<DescriptorSetLayout> layout;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
@@ -2,6 +2,7 @@
 
 #include "bx/engine/core/guard.hpp"
 #include "bx/engine/containers/string.hpp"
+#include "bx/engine/containers/array.hpp"
 
 #include "vulkan_api.hpp"
 
@@ -29,6 +30,10 @@ namespace Vk
 
     private:
         VkDescriptorSet descriptorSet;
+
+        Array<std::shared_ptr<Buffer>, 128> trackedBuffers;
+        Array<std::shared_ptr<Image>, 128> trackedImages;
+        Array<std::shared_ptr<Sampler>, 128> trackedSamplers;
 
         const std::shared_ptr<Device> device;
         const std::shared_ptr<DescriptorPool> pool;

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bx/engine/core/guard.hpp"
+#include "bx/engine/core/type.hpp"
 #include "bx/engine/containers/string.hpp"
 #include "bx/engine/containers/array.hpp"
 
@@ -27,16 +28,17 @@ namespace Vk
         void SetImage(uint32_t binding, VkDescriptorType type, std::shared_ptr<Image> image,
             std::shared_ptr<Sampler> sampler);
 
-        void TransitionResourceStates(std::shared_ptr<CmdList> cmdList) const;
+        void TransitionResourceStates(std::shared_ptr<CmdList> cmdList, b8 isGraphics) const;
 
         VkDescriptorSet GetDescriptorSet() const;
 
     private:
         VkDescriptorSet descriptorSet;
 
-        Array<std::shared_ptr<Buffer>, 128> trackedBuffers;
-        Array<std::shared_ptr<Image>, 128> trackedImages;
-        Array<std::shared_ptr<Sampler>, 128> trackedSamplers;
+        Array<std::shared_ptr<Buffer>, 64> trackedBuffers;
+        Array<std::shared_ptr<Image>, 64> trackedSampledImages;
+        Array<std::shared_ptr<Image>, 64> trackedStorageImages;
+        Array<std::shared_ptr<Sampler>, 64> trackedSamplers;
 
         const std::shared_ptr<Device> device;
         const std::shared_ptr<DescriptorPool> pool;

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp
@@ -14,6 +14,7 @@ namespace Vk
     class Buffer;
     class Image;
     class Sampler;
+    class CmdList;
 
     class DescriptorSet : NoCopy {
     public:
@@ -25,6 +26,8 @@ namespace Vk
         void SetBuffer(uint32_t binding, VkDescriptorType type, std::shared_ptr<Buffer> buffer);
         void SetImage(uint32_t binding, VkDescriptorType type, std::shared_ptr<Image> image,
             std::shared_ptr<Sampler> sampler);
+
+        void TransitionResourceStates(std::shared_ptr<CmdList> cmdList) const;
 
         VkDescriptorSet GetDescriptorSet() const;
 

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+#include "bx/engine/containers/list.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+
+    class DescriptorSetLayout : NoCopy {
+    public:
+        DescriptorSetLayout(const String& name, const std::shared_ptr<Device> device,
+            const List<VkDescriptorSetLayoutBinding>& bindings);
+        ~DescriptorSetLayout();
+
+        VkDescriptorSetLayout GetLayout() const;
+
+    private:
+        VkDescriptorSetLayout layout;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp
@@ -2,6 +2,7 @@
 
 #include "bx/engine/core/guard.hpp"
 #include "bx/engine/containers/string.hpp"
+#include "bx/engine/containers/hash_map.hpp"
 #include "bx/engine/containers/list.hpp"
 
 #include "vulkan_api.hpp"
@@ -19,9 +20,12 @@ namespace Vk
         DescriptorSetLayout& operator=(DescriptorSetLayout&& other) noexcept;
 
         VkDescriptorSetLayout GetLayout() const;
+        VkDescriptorType GetDescriptorType(u32 binding) const;
 
     private:
         VkDescriptorSetLayout layout;
+
+        HashMap<u32, VkDescriptorType> descriptorTypes;
 
         const std::shared_ptr<Device> device;
     };

--- a/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp
@@ -15,6 +15,8 @@ namespace Vk
         DescriptorSetLayout(const String& name, const std::shared_ptr<Device> device,
             const List<VkDescriptorSetLayoutBinding>& bindings);
         ~DescriptorSetLayout();
+        DescriptorSetLayout(DescriptorSetLayout&& other) noexcept;
+        DescriptorSetLayout& operator=(DescriptorSetLayout&& other) noexcept;
 
         VkDescriptorSetLayout GetLayout() const;
 

--- a/include/bx/engine/modules/graphics/backend/vulkan/device.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/device.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Instance;
+	class PhysicalDevice;
+
+    class Device : NoCopy {
+    public:
+        Device(std::shared_ptr<Instance> instance,
+            const PhysicalDevice& physicalDevice, bool debug);
+        ~Device();
+
+        void WaitIdle() const;
+
+        VkDevice GetDevice() const;
+        VmaAllocator GetAllocator() const;
+
+    private:
+        VkDevice device;
+        VmaAllocator allocator;
+
+        const std::shared_ptr<Instance> instance;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/extensions.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/extensions.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "vulkan_api.hpp"
+
+#include "bx/engine/containers/list.hpp"
+
+namespace Vk
+{
+    static const List<const char*> instanceExtensions = { VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+                                                                VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+                                                                VK_KHR_SURFACE_EXTENSION_NAME };
+    static const List<const char*> deviceExtensions = {
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+        VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME };
+
+    static const List<const char*> deviceRaytracingExtensions = {
+        VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+        VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
+        VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+        VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
+        VK_KHR_SPIRV_1_4_EXTENSION_NAME,
+        VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME };
+
+    bool CheckDeviceExtensionSupport(VkPhysicalDevice physicalDevice);
+    bool CheckDeviceRaytracingExtensionSupport(VkPhysicalDevice physicalDevice);
+
+    List<const char*> PlatformInstanceExtensions();
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/extensions.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/extensions.hpp
@@ -12,7 +12,7 @@ namespace Vk
     static const List<const char*> deviceExtensions = {
         VK_KHR_SWAPCHAIN_EXTENSION_NAME,
         VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME };
-
+    
     static const List<const char*> deviceRaytracingExtensions = {
         VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
         VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,

--- a/include/bx/engine/modules/graphics/backend/vulkan/fence.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/fence.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	class Device;
+
+    class Fence : NoCopy {
+    public:
+        Fence(const String& name, std::shared_ptr<Device> device, bool signaled = false);
+        ~Fence();
+        explicit Fence(Fence&& other) noexcept;
+        Fence& operator=(Fence&& other) noexcept;
+
+        bool IsComplete() const;
+        void Wait() const;
+        void Reset();
+
+        VkFence GetFence() const;
+
+    private:
+        VkFence fence;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/list.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class RenderPass;
+    class Device;
+    class Image;
+
+    class Framebuffer : NoCopy {
+    public:
+        Framebuffer(const String& name, std::shared_ptr<Device> device,
+            List<std::shared_ptr<Image>> images,
+            std::shared_ptr<RenderPass> renderPass);
+        ~Framebuffer();
+
+        explicit Framebuffer(Framebuffer&& other) noexcept;
+        Framebuffer& operator=(Framebuffer&& other) noexcept;
+
+        const List<std::shared_ptr<Image>>& Images() const;
+
+        VkFramebuffer GetFramebuffer() const;
+
+    private:
+        VkFramebuffer framebuffer;
+        std::shared_ptr<RenderPass> renderPass;
+        List<std::shared_ptr<Image>> images;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp
@@ -1,22 +1,44 @@
 #pragma once
 
+#include "bx/engine/core/type.hpp"
 #include "bx/engine/core/guard.hpp"
+#include "bx/engine/core/hash.hpp"
 #include "bx/engine/containers/list.hpp"
 #include "bx/engine/containers/string.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
 
 #include "vulkan_api.hpp"
 
 namespace Vk
 {
-    class RenderPass;
     class Device;
-    class Image;
+
+    struct FramebufferInfo
+    {
+        List<std::shared_ptr<Image>> images;
+        std::shared_ptr<RenderPass> renderPass;
+
+        b8 operator==(const FramebufferInfo& other) const
+        {
+            if (images.size() != other.images.size())
+                return false;
+
+            for (u32 i = 0; i < images.size(); i++)
+            {
+                if (images[i] != other.images[i])
+                    return false;
+            }
+
+            return renderPass == other.renderPass;
+        }
+    };
 
     class Framebuffer : NoCopy {
     public:
         Framebuffer(const String& name, std::shared_ptr<Device> device,
-            List<std::shared_ptr<Image>> images,
-            std::shared_ptr<RenderPass> renderPass);
+            const FramebufferInfo& info);
         ~Framebuffer();
 
         explicit Framebuffer(Framebuffer&& other) noexcept;
@@ -34,3 +56,18 @@ namespace Vk
         const std::shared_ptr<Device> device;
     };
 }
+
+template <>
+struct std::hash<Vk::FramebufferInfo>
+{
+    std::size_t operator()(const Vk::FramebufferInfo& v) const
+    {
+        SizeType result = 0;
+        for (auto& image : v.images) {
+            const Vk::Image& dimage = *image;
+            hashCombine<Vk::Image>(result, dimage);
+        }
+        hashCombine<Vk::RenderPass>(result, *v.renderPass);
+        return result;
+    }
+};

--- a/include/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/list.hpp"
+
+#include "vulkan_api.hpp"
+
+#include <memory>
+
+namespace Vk
+{
+    class DescriptorSetLayout;
+    class Device;
+    class RenderPass;
+    class Shader;
+
+    struct PushConstantRange {
+        PushConstantRange(const std::string& name, size_t size, VkShaderStageFlags stageFlags)
+            : name(name), size(size), stageFlags(stageFlags) {
+        }
+
+        const std::string name;
+        const size_t size;
+        const VkShaderStageFlags stageFlags;
+    };
+
+    struct GraphicsPipelineInfo {
+        bool ignoreDepth = false;
+        bool blending = false;
+        bool inputVertices = true;
+        VkPolygonMode polygonMode = VK_POLYGON_MODE_FILL;
+        bool culling = true;
+    };
+
+    class GraphicsPipeline : NoCopy {
+    public:
+        GraphicsPipeline(std::shared_ptr<Device> device,
+            const List<const Shader*>& shaders,
+            std::shared_ptr<RenderPass> renderPass,
+            List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts,
+            List<PushConstantRange> pushConstants, GraphicsPipelineInfo info);
+        ~GraphicsPipeline();
+
+        const GraphicsPipelineInfo& Info() const;
+
+        VkPipeline GetPipeline() const;
+        VkPipelineLayout GetLayout() const;
+
+    private:
+        VkPipelineLayout pipelineLayout;
+        VkPipeline pipeline;
+        GraphicsPipelineInfo info;
+
+        const std::shared_ptr<Device> device;
+        const std::shared_ptr<RenderPass> renderPass;
+        const List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp
@@ -30,6 +30,9 @@ namespace Vk
         bool inputVertices = true;
         VkPolygonMode polygonMode = VK_POLYGON_MODE_FILL;
         bool culling = true;
+
+        List<VkVertexInputBindingDescription> vertexBindingDescriptions{};
+        List<VkVertexInputAttributeDescription> vertexAttributeDescriptions{};
     };
 
     class GraphicsPipeline : NoCopy {

--- a/include/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp
@@ -37,7 +37,7 @@ namespace Vk
         GraphicsPipeline(std::shared_ptr<Device> device,
             const List<const Shader*>& shaders,
             std::shared_ptr<RenderPass> renderPass,
-            List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts,
+            const List<std::shared_ptr<DescriptorSetLayout>>& descriptorSetLayouts,
             List<PushConstantRange> pushConstants, GraphicsPipelineInfo info);
         ~GraphicsPipeline();
 

--- a/include/bx/engine/modules/graphics/backend/vulkan/image.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/image.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	class Device;
+	class PhysicalDevice;
+
+    class Image : NoCopy {
+    public:
+        Image(const String& name, std::shared_ptr<Device> device,
+            const PhysicalDevice& physicalDevice, uint32_t width, uint32_t height, uint32_t mips,
+            VkImageUsageFlags usage, VkFormat format, uint32_t arrayLayers = 1,
+            VkImageType type = VK_IMAGE_TYPE_2D, uint32_t depth = 1);
+        Image(const String& name, std::shared_ptr<Device> device, VkImage image, VkImageView imageView,
+            uint32_t width, uint32_t height);
+        ~Image();
+
+        uint32_t Width() const;
+        uint32_t Height() const;
+        uint32_t Depth() const;
+        uint32_t Mips() const;
+        uint32_t ArrayLayers() const;
+        VkFormat Format() const;
+
+        VkImage GetImage() const;
+        VkImageView GetImageView() const;
+
+    private:
+        const std::shared_ptr<Device> device;
+
+        VkImage image;
+        VkImageView imageView;
+        VmaAllocation allocation;
+
+        uint32_t width;
+        uint32_t height;
+        uint32_t depth;
+        uint32_t mips;
+        uint32_t arrayLayers;
+        VkFormat format;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/image.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/image.hpp
@@ -32,6 +32,7 @@ namespace Vk
         VkImageView GetImageView() const;
 
     private:
+        const String name;
         const std::shared_ptr<Device> device;
 
         VkImage image;

--- a/include/bx/engine/modules/graphics/backend/vulkan/image.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/image.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bx/engine/core/guard.hpp"
+#include "bx/engine/core/hash.hpp"
 #include "bx/engine/containers/string.hpp"
 
 #include "vulkan_api.hpp"
@@ -45,3 +46,14 @@ namespace Vk
         VkFormat format;
     };
 }
+
+template <>
+struct std::hash<Vk::Image>
+{
+    std::size_t operator()(const Vk::Image& v) const
+    {
+        SizeType result = 0;
+        hashCombine(result, v.GetImage());
+        return result;
+    }
+};

--- a/include/bx/engine/modules/graphics/backend/vulkan/image_format.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/image_format.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	inline bool IsDepthFormat(VkFormat format)
+	{
+		return format == VK_FORMAT_D32_SFLOAT || format == VK_FORMAT_D24_UNORM_S8_UINT;
+	}
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/image_format.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/image_format.hpp
@@ -13,4 +13,28 @@ namespace Vk
 	{
 		return format == VK_FORMAT_D24_UNORM_S8_UINT;
 	}
+
+	inline VkImageLayout GetDepthStencilLayout(VkFormat format)
+	{
+		b8 depth = 
+			format == VK_FORMAT_D16_UNORM || format == VK_FORMAT_D32_SFLOAT ||
+			format == VK_FORMAT_D24_UNORM_S8_UINT || format == VK_FORMAT_D32_SFLOAT ||
+			format == VK_FORMAT_D32_SFLOAT_S8_UINT;
+		b8 stencil =
+			format == VK_FORMAT_S8_UINT || format == VK_FORMAT_D24_UNORM_S8_UINT ||
+			format == VK_FORMAT_D32_SFLOAT_S8_UINT;
+
+		if (depth && stencil)
+		{
+			return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+		}
+		else if (depth)
+		{
+			return VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+		}
+		else
+		{
+			return VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
+		}
+	}
 }

--- a/include/bx/engine/modules/graphics/backend/vulkan/image_format.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/image_format.hpp
@@ -8,4 +8,9 @@ namespace Vk
 	{
 		return format == VK_FORMAT_D32_SFLOAT || format == VK_FORMAT_D24_UNORM_S8_UINT;
 	}
+
+	inline bool IsStencilFormat(VkFormat format)
+	{
+		return format == VK_FORMAT_D24_UNORM_S8_UINT;
+	}
 }

--- a/include/bx/engine/modules/graphics/backend/vulkan/pfn.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/pfn.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	class Pfn
+	{
+	public:
+		static void Load(VkInstance instance);
+
+        static PFN_vkGetBufferDeviceAddress vkGetBufferDeviceAddress;
+
+        static PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT;
+        static PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT;
+        static PFN_vkDestroyDebugReportCallbackEXT vkDestroyDebugReportCallbackEXT;
+
+        static PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR;
+        static PFN_vkDestroyAccelerationStructureKHR vkDestroyAccelerationStructureKHR;
+        static PFN_vkGetAccelerationStructureBuildSizesKHR vkGetAccelerationStructureBuildSizesKHR;
+        static PFN_vkCmdBuildAccelerationStructuresKHR vkCmdBuildAccelerationStructuresKHR;
+	};
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/physical_device.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/physical_device.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Instance;
+
+    struct RTProperties {
+        VkPhysicalDeviceAccelerationStructurePropertiesKHR accelProperties;
+        VkPhysicalDeviceRayTracingPipelinePropertiesKHR pipelineProperties;
+    };
+
+    class PhysicalDevice : NoCopy {
+    public:
+        PhysicalDevice(const Instance& instance);
+
+        VkPhysicalDevice GetPhysicalDevice() const;
+        bool RayTracingSuitable() const;
+        const RTProperties& RayTracingProperties() const;
+        uint32_t GraphicsFamily() const;
+        uint32_t ComputeFamily() const;
+        uint32_t PresentFamily() const;
+
+        uint32_t FindMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) const;
+
+    private:
+        VkPhysicalDevice physicalDevice;
+        bool rayTracingSuitable;
+        RTProperties rayTracingProperties;
+        uint32_t graphicsFamily;
+        uint32_t computeFamily;
+        uint32_t presentFamily;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/rect2d.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/rect2d.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "bx/engine/core/math.hpp"
+
+namespace Vk
+{
+    // TODO: maybe this can go into math.hpp?
+    struct Rect2D {
+        Rect2D() = default;
+        Rect2D(float width, float height) : offset{}, extent(width, height) {
+        }
+
+        Vec2 offset;
+        Vec2 extent;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
@@ -18,6 +18,20 @@ namespace Vk
     {
         List<VkFormat> colorFormats;
         Optional<VkFormat> depthFormat = Optional<VkFormat>::None();
+
+        b8 operator==(const RenderPassInfo& other) const
+        {
+            if (colorFormats.size() != other.colorFormats.size())
+                return false;
+
+            for (u32 i = 0; i < colorFormats.size(); i++)
+            {
+                if (colorFormats[i] != other.colorFormats[i])
+                    return false;
+            }
+
+            return depthFormat == other.depthFormat;
+        }
     };
 
     class RenderPass : NoCopy {
@@ -48,4 +62,15 @@ struct std::hash<Vk::RenderPassInfo>
             hashCombine(result, v.depthFormat.Unwrap());
 		return result;
 	}
+};
+
+template <>
+struct std::hash<Vk::RenderPass>
+{
+    std::size_t operator()(const Vk::RenderPass& v) const
+    {
+        SizeType result = 0;
+        hashCombine(result, v.GetRenderPass());
+        return result;
+    }
 };

--- a/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bx/engine/core/guard.hpp"
+#include "bx/engine/core/hash.hpp"
 #include "bx/engine/containers/optional.hpp"
 #include "bx/engine/containers/list.hpp"
 #include "bx/engine/containers/string.hpp"
@@ -13,12 +14,17 @@ namespace Vk
 {
     class Device;
 
+    struct RenderPassInfo
+    {
+        List<VkFormat> colorFormats;
+        Optional<VkFormat> depthFormat = Optional<VkFormat>::None();
+    };
+
     class RenderPass : NoCopy {
     public:
         RenderPass(const String& name,
             std::shared_ptr<Device> device,
-            const List<VkFormat>& colorFormats,
-            const Optional<VkFormat>& depthFormat);
+            const RenderPassInfo& info);
         ~RenderPass();
 
         VkRenderPass GetRenderPass() const;
@@ -29,3 +35,17 @@ namespace Vk
         const std::shared_ptr<Device> device;
     };
 }
+
+template <>
+struct std::hash<Vk::RenderPassInfo>
+{
+	std::size_t operator()(const Vk::RenderPassInfo& v) const
+	{
+        SizeType result = 0;
+        for (auto& format : v.colorFormats)
+            hashCombine(result, format);
+        if (v.depthFormat.IsSome())
+            hashCombine(result, v.depthFormat.Unwrap());
+		return result;
+	}
+};

--- a/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/optional.hpp"
+#include "bx/engine/containers/list.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+#include <memory>
+
+namespace Vk
+{
+    class Device;
+
+    class RenderPass : NoCopy {
+    public:
+        RenderPass(const String& name,
+            std::shared_ptr<Device> device,
+            const List<VkFormat>& colorFormats,
+            const Optional<VkFormat>& depthFormat);
+        ~RenderPass();
+
+        VkRenderPass GetRenderPass() const;
+
+    private:
+        VkRenderPass renderPass;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/render_pass.hpp
@@ -18,6 +18,7 @@ namespace Vk
     {
         List<VkFormat> colorFormats;
         Optional<VkFormat> depthFormat = Optional<VkFormat>::None();
+        b8 clear = true;
 
         b8 operator==(const RenderPassInfo& other) const
         {
@@ -30,7 +31,7 @@ namespace Vk
                     return false;
             }
 
-            return depthFormat == other.depthFormat;
+            return depthFormat == other.depthFormat && clear == other.clear;
         }
     };
 

--- a/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
@@ -10,20 +10,19 @@ namespace Vk
     class Image;
 
     struct ImageState {
-        VkImageLayout layout;
-        VkAccessFlags accessFlags;
-        VkPipelineStageFlags stageFlags;
+        VkImageLayout currentLayout;
+        VkPipelineStageFlags lastStageFlags;
 
         b8 operator==(const ImageState& other) const
         {
-            return layout == other.layout && accessFlags == other.accessFlags && stageFlags == other.stageFlags;
+            return currentLayout == other.currentLayout && lastStageFlags == other.lastStageFlags;
         }
     };
 
     class ResourceStateTracker {
     public:
         static void TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
-            ImageState newState);
+            VkImageLayout newLayout, VkPipelineStageFlags newStage);
 
         static void AddGlobalImageState(VkImage image, ImageState state);
         static void RemoveGlobalImageState(VkImage image);

--- a/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
@@ -24,6 +24,9 @@ namespace Vk
         static void TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
             VkImageLayout newLayout, VkPipelineStageFlags newStage);
 
+        static VkImageLayout GetCurrentImageLayout(const Image& image);
+        static void ApplyImplicitImageTransition(const Image& image, VkImageLayout newLayout);
+
         static void AddGlobalImageState(VkImage image, ImageState state);
         static void RemoveGlobalImageState(VkImage image);
 

--- a/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/hash_map.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Image;
+
+    struct ImageState {
+        VkImageLayout layout;
+        VkAccessFlags accessFlags;
+        VkPipelineStageFlags stageFlags;
+    };
+
+    class ResourceStateTracker {
+    public:
+        static void TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
+            ImageState newState);
+
+        static void AddGlobalImageState(VkImage image, ImageState state);
+        static void RemoveGlobalImageState(VkImage image);
+
+    private:
+        static HashMap<VkImage, ImageState> globalImageStates;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp
@@ -13,6 +13,11 @@ namespace Vk
         VkImageLayout layout;
         VkAccessFlags accessFlags;
         VkPipelineStageFlags stageFlags;
+
+        b8 operator==(const ImageState& other) const
+        {
+            return layout == other.layout && accessFlags == other.accessFlags && stageFlags == other.stageFlags;
+        }
     };
 
     class ResourceStateTracker {

--- a/include/bx/engine/modules/graphics/backend/vulkan/sampler.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/sampler.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+    class PhysicalDevice;
+
+    struct SamplerInfo {
+        VkFilter filterMode = VK_FILTER_LINEAR;
+    };
+
+    class Sampler : NoCopy {
+    public:
+        Sampler(const String& name, std::shared_ptr<Device> device,
+            const PhysicalDevice& physicalDevice, const SamplerInfo& info);
+        ~Sampler();
+
+        VkSampler GetSampler() const;
+
+    private:
+        VkSampler sampler;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/semaphore.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/semaphore.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+
+    class Semaphore : NoCopy {
+    public:
+        Semaphore(const String& name, std::shared_ptr<Device> device);
+        ~Semaphore();
+        explicit Semaphore(Semaphore&& other) noexcept;
+        Semaphore& operator=(Semaphore&& other) noexcept;
+
+        VkSemaphore GetSemaphore() const;
+
+    private:
+        VkSemaphore semaphore;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/shader.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/shader.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+	class Device;
+
+    class Shader : NoCopy {
+    public:
+        Shader(const String& name, std::shared_ptr<Device> device, VkShaderStageFlagBits stage, const String& src);
+        ~Shader();
+
+        VkShaderModule GetShader() const;
+
+    private:
+        VkShaderModule shader;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/spirv_compiler.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/spirv_compiler.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "bx/engine/core/type.hpp"
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/string.hpp"
+#include "bx/engine/containers/list.hpp"
+
+#include "vulkan_api.hpp"
+
+#include <glslang/Include/glslang_c_shader_types.h>
+
+namespace Vk
+{
+    class SpirVCompiler
+    {
+    public:
+        static SpirVCompiler& Instance();
+        ~SpirVCompiler();
+
+        List<u32> Compile(const String& name, glslang_stage_t stage, const String& src);
+
+    private:
+        SpirVCompiler();
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/swapchain.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/swapchain.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "bx/engine/core/type.hpp"
 #include "bx/engine/core/guard.hpp"
 #include "bx/engine/containers/list.hpp"
+
+#include "bx/engine/modules/graphics/type.hpp"
 
 #include "vulkan_api.hpp"
 
@@ -23,6 +26,10 @@ namespace Vk
         Swapchain(uint32_t width, uint32_t height, const Instance& instance,
             std::shared_ptr<Device> device, const PhysicalDevice& physicalDevice);
         ~Swapchain();
+
+        TextureCreateInfo GetImageCreateInfo() const;
+
+        std::shared_ptr<Image> GetImage(u32 idx) const;
 
         const Framebuffer& GetCurrentFramebuffer() const;
         const Image& GetCurrentImage() const;
@@ -46,6 +53,7 @@ namespace Vk
         VkSurfaceFormatKHR format;
         VkPresentModeKHR presentMode;
         VkExtent2D extent;
+        TextureCreateInfo imageCreateInfo;
 
         uint32_t imageCount;
         List<std::shared_ptr<Image>> images;

--- a/include/bx/engine/modules/graphics/backend/vulkan/swapchain.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/swapchain.hpp
@@ -31,7 +31,7 @@ namespace Vk
 
         std::shared_ptr<Image> GetImage(u32 idx) const;
 
-        const Framebuffer& GetCurrentFramebuffer() const;
+        std::shared_ptr<Framebuffer> GetCurrentFramebuffer() const;
         const Image& GetCurrentImage() const;
         uint32_t GetCurrentFrameIdx() const;
         Semaphore& GetImageAvailableSemaphore();
@@ -57,7 +57,7 @@ namespace Vk
 
         uint32_t imageCount;
         List<std::shared_ptr<Image>> images;
-        List<Framebuffer> framebuffers;
+        List<std::shared_ptr<Framebuffer>> framebuffers;
 
         uint32_t currentFrame;
         uint32_t currentImage;

--- a/include/bx/engine/modules/graphics/backend/vulkan/swapchain.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/swapchain.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "bx/engine/core/guard.hpp"
+#include "bx/engine/containers/list.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Instance;
+    class Device;
+    class PhysicalDevice;
+    class RenderPass;
+    class Image;
+    class Framebuffer;
+    class Semaphore;
+    class Fence;
+    class CmdQueue;
+    struct Rect2D;
+
+    class Swapchain : NoCopy {
+    public:
+        Swapchain(uint32_t width, uint32_t height, const Instance& instance,
+            std::shared_ptr<Device> device, const PhysicalDevice& physicalDevice);
+        ~Swapchain();
+
+        const Framebuffer& GetCurrentFramebuffer() const;
+        const Image& GetCurrentImage() const;
+        uint32_t GetCurrentFrameIdx() const;
+        Semaphore& GetImageAvailableSemaphore();
+        Semaphore& GetRenderFinishedSemaphore();
+
+        std::shared_ptr<RenderPass> GetRenderPass();
+
+        std::shared_ptr<Fence> NextImage();
+        void Present(const CmdQueue& queue, const Fence& fence,
+            const List<Semaphore*>& semaphores);
+
+        VkFormat Format() const;
+        Rect2D Extent() const;
+
+        const static uint32_t MAX_FRAMES_IN_FLIGHT = 2;
+
+    private:
+        VkSwapchainKHR swapchain;
+        VkSurfaceFormatKHR format;
+        VkPresentModeKHR presentMode;
+        VkExtent2D extent;
+
+        uint32_t imageCount;
+        List<std::shared_ptr<Image>> images;
+        List<Framebuffer> framebuffers;
+
+        uint32_t currentFrame;
+        uint32_t currentImage;
+        List<Semaphore> imageAvailableSemaphores;
+        List<Semaphore> renderFinishedSemaphores;
+        List<std::shared_ptr<Fence>> inFlightFences;
+
+        std::shared_ptr<RenderPass> renderPass;
+
+        const std::shared_ptr<Device> device;
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/validation.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/validation.hpp
@@ -2,8 +2,20 @@
 
 #include "bx/engine/containers/list.hpp"
 #include "bx/engine/containers/string.hpp"
+#include "bx/engine/core/macros.hpp"
 
 #include "vulkan_api.hpp"
+
+#define VK_ASSERT(condition, ...) \
+    do { \
+        if (!(condition)) \
+        { \
+			BX_LOGE("Vulkan failed: {}", Log::Format(__VA_ARGS__)); \
+            std::abort(); \
+        } \
+    } while (false)
+
+#define VK_ENSURE(condition) VK_ASSERT(condition, #condition)
 
 namespace Vk
 {

--- a/include/bx/engine/modules/graphics/backend/vulkan/validation.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/validation.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "bx/engine/containers/list.hpp"
+#include "bx/engine/containers/string.hpp"
+
+#include "vulkan_api.hpp"
+
+namespace Vk
+{
+    class Device;
+
+	static const List<const char*> validationLayers = { "VK_LAYER_KHRONOS_validation" };
+
+    void CheckValidationLayerSupport();
+
+    VkBool32 VKAPI_PTR VulkanDebugCallback(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType,
+        uint64_t srcObject, size_t location, int32_t msgCode,
+        const char* pLayerPrefix, const char* pMsg, void* pUserData);
+
+    class DebugNames
+    {
+    public:
+        static void Set(const Device& device, VkObjectType type, uint64_t handle,
+            const String& name);
+    };
+}

--- a/include/bx/engine/modules/graphics/backend/vulkan/vulkan_api.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/vulkan_api.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#define VULKAN_VERSION VK_API_VERSION_1_2
+#define VMA_VULKAN_VERSION 1002000
+
+// TODO: rename platform pc to platform windows?
+#ifdef BX_PLATFORM_PC
+#define VK_USE_PLATFORM_WIN32_KHR
+#elif defined BX_PLATFORM_LINUX
+// TODO
+#endif // BX_PLATFORM_PC
+
+#ifdef BX_WINDOW_GLFW_BACKEND
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+
+#ifdef BX_PLATFORM_PC
+#define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined BX_PLATFORM_LINUX
+// TODO
+#endif // BX_PLATFORM_PC
+#include <GLFW/glfw3native.h>
+#endif // BX_WINDOW_GLFW_BACKEND
+
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
+#include <vulkan/vulkan.hpp>
+#include <vk_mem_alloc.h>

--- a/include/bx/engine/modules/graphics/type.hpp
+++ b/include/bx/engine/modules/graphics/type.hpp
@@ -622,7 +622,9 @@ struct ComputePassDescriptor
 
 b8 IsVertexFormatInt(const VertexFormat& format);
 b8 IsTextureFormatSrgb(const TextureFormat& format);
+b8 IsTextureFormatDepth(const TextureFormat& format);
 u32 SizeOfTextureFormat(const TextureFormat& format);
+b8 IsBufferUsageMappable(const BufferUsageFlags& usage);
 
 // TODO: remove
 struct DebugVertex

--- a/include/bx/engine/modules/graphics/type.hpp
+++ b/include/bx/engine/modules/graphics/type.hpp
@@ -623,6 +623,7 @@ struct ComputePassDescriptor
 b8 IsVertexFormatInt(const VertexFormat& format);
 b8 IsTextureFormatSrgb(const TextureFormat& format);
 b8 IsTextureFormatDepth(const TextureFormat& format);
+b8 IsTextureFormatStencil(const TextureFormat& format);
 u32 SizeOfTextureFormat(const TextureFormat& format);
 b8 IsBufferUsageMappable(const BufferUsageFlags& usage);
 u32 SizeOfTexturePixels(const TextureCreateInfo& info);

--- a/include/bx/engine/modules/graphics/type.hpp
+++ b/include/bx/engine/modules/graphics/type.hpp
@@ -625,6 +625,7 @@ b8 IsTextureFormatSrgb(const TextureFormat& format);
 b8 IsTextureFormatDepth(const TextureFormat& format);
 u32 SizeOfTextureFormat(const TextureFormat& format);
 b8 IsBufferUsageMappable(const BufferUsageFlags& usage);
+u32 SizeOfTexturePixels(const TextureCreateInfo& info);
 
 // TODO: remove
 struct DebugVertex

--- a/include/bx/framework/resources/shader.hpp
+++ b/include/bx/framework/resources/shader.hpp
@@ -2,8 +2,11 @@
 
 #include <bx/engine/core/math.hpp>
 #include <bx/engine/containers/string.hpp>
+#include <bx/engine/containers/hash_set.hpp>
 #include <bx/engine/containers/list.hpp>
 #include <bx/engine/modules/graphics.hpp>
+
+String ResolveShaderIncludes(const String& source);
 
 class Shader
 {

--- a/src/bx/editor/views/scene_view.cpp
+++ b/src/bx/editor/views/scene_view.cpp
@@ -15,6 +15,8 @@
 
 #ifdef BX_GRAPHICS_OPENGL_BACKEND
 #include <bx/engine/modules/graphics/backend/graphics_opengl.hpp>
+#elif defined(BX_GRAPHICS_VULKAN_BACKEND)
+#include <bx/engine/modules/graphics/backend/graphics_vulkan.hpp>
 #endif
 #include <bx/framework/systems/renderer/id_pass.hpp>
 
@@ -285,8 +287,12 @@ void SceneView::Present(bool& show)
 
     Render(contentRegionAvail);
 #ifdef BX_GRAPHICS_VULKAN_BACKEND
-    // TODO: ???
-    //ImGui::Image((void*)(intptr_t)GraphicsOpenGL::GetTextureHandle(g_renderTarget), contentRegionAvail, ImVec2(0, 1), ImVec2(1, 0));
+    TextureHandle editorCameraColorTarget = Renderer::GetEditorCameraColorTarget();
+    if (editorCameraColorTarget)
+    {
+        std::shared_ptr<Vk::DescriptorSet> descriptorSet = GraphicsVulkan::TextureAsDescriptorSet(editorCameraColorTarget);
+        ImGui::Image((void*)descriptorSet->GetDescriptorSet(), contentRegionAvail);
+    }
 #elif defined BX_GRAPHICS_OPENGL_BACKEND
     TextureHandle editorCameraColorTarget = Renderer::GetEditorCameraColorTarget();
     if (editorCameraColorTarget)

--- a/src/bx/editor/views/scene_view.cpp
+++ b/src/bx/editor/views/scene_view.cpp
@@ -343,7 +343,6 @@ void SceneView::Present(bool& show)
 
         u64 pixelData = 0;
         Graphics::ReadTexture(g_idColorTarget, &pixelData, Extend3D((u32)relMousePos.x, (u32)relMousePos.y, 0), Extend3D(1, 1, 1));
-        BX_LOGI("SELECT: {}", pixelData);
         if (pixelData != 0)
         {
             Selection::SetSelected(Object<Entity>(pixelData));

--- a/src/bx/editor/views/scene_view.cpp
+++ b/src/bx/editor/views/scene_view.cpp
@@ -146,7 +146,7 @@ void SceneView::Render(const ImVec2& size)
         idColorTargetCreateInfo.name = "Id Pass Color Target";
         idColorTargetCreateInfo.size = Extend3D(g_sceneSize.x, g_sceneSize.y, 1);
         idColorTargetCreateInfo.format = TextureFormat::RG32_UINT;
-        idColorTargetCreateInfo.usageFlags = TextureUsageFlags::RENDER_ATTACHMENT;
+        idColorTargetCreateInfo.usageFlags = TextureUsageFlags::RENDER_ATTACHMENT | TextureUsageFlags::COPY_SRC;
         if (g_idColorTarget) Graphics::DestroyTexture(g_idColorTarget);
         g_idColorTarget = Graphics::CreateTexture(idColorTargetCreateInfo);
 
@@ -290,8 +290,11 @@ void SceneView::Present(bool& show)
     TextureHandle editorCameraColorTarget = Renderer::GetEditorCameraColorTarget();
     if (editorCameraColorTarget)
     {
-        std::shared_ptr<Vk::DescriptorSet> descriptorSet = GraphicsVulkan::TextureAsDescriptorSet(editorCameraColorTarget);
-        ImGui::Image((void*)descriptorSet->GetDescriptorSet(), contentRegionAvail);
+        static std::shared_ptr<Vk::DescriptorSet> descriptorSets[3];
+
+        u32 frameIdx = GraphicsVulkan::GetCurrentFrameIdx();
+        descriptorSets[frameIdx] = GraphicsVulkan::TextureAsDescriptorSet(editorCameraColorTarget);
+        ImGui::Image((void*)descriptorSets[frameIdx]->GetDescriptorSet(), contentRegionAvail);
     }
 #elif defined BX_GRAPHICS_OPENGL_BACKEND
     TextureHandle editorCameraColorTarget = Renderer::GetEditorCameraColorTarget();
@@ -337,9 +340,10 @@ void SceneView::Present(bool& show)
         ImVec2 windowPos = ImGui::GetWindowPos();
         ImVec2 windowSize = ImGui::GetWindowSize();
         ImVec2 relMousePos = ImVec2(mousePos.x - windowPos.x, windowPos.y + windowSize.y - mousePos.y);
-        
+
         u64 pixelData = 0;
         Graphics::ReadTexture(g_idColorTarget, &pixelData, Extend3D((u32)relMousePos.x, (u32)relMousePos.y, 0), Extend3D(1, 1, 1));
+        BX_LOGI("SELECT: {}", pixelData);
         if (pixelData != 0)
         {
             Selection::SetSelected(Object<Entity>(pixelData));

--- a/src/bx/engine/core/uuid.cpp
+++ b/src/bx/engine/core/uuid.cpp
@@ -3,16 +3,19 @@
 #include <ctime>
 #include <cstdint>
 
-Uuid GenUuid::MakeUuid()
+namespace BX
 {
-    // Get current time since epoch in seconds
-    u64 timePart = static_cast<u64>(time(nullptr));
-
-    // Simple linear congruential generator for random number generation
-    static u64 seed = time(nullptr);
-    seed = (6364136223846793005ULL * seed + 1);
-    u32 randomPart = static_cast<u32>(seed >> 32);
-
-    // Combine time part and random part to form the UUID
-    return (timePart << 32) | randomPart;
+    UUID GenUuid::MakeUuid()
+    {
+        // Get current time since epoch in seconds
+        u64 timePart = static_cast<u64>(time(nullptr));
+    
+        // Simple linear congruential generator for random number generation
+        static u64 seed = time(nullptr);
+        seed = (6364136223846793005ULL * seed + 1);
+        u32 randomPart = static_cast<u32>(seed >> 32);
+    
+        // Combine time part and random part to form the UUID
+        return (timePart << 32) | randomPart;
+    }
 }

--- a/src/bx/engine/core/uuid.cpp
+++ b/src/bx/engine/core/uuid.cpp
@@ -3,7 +3,7 @@
 #include <ctime>
 #include <cstdint>
 
-UUID GenUUID::MakeUUID()
+Uuid GenUuid::MakeUuid()
 {
     // Get current time since epoch in seconds
     u64 timePart = static_cast<u64>(time(nullptr));

--- a/src/bx/engine/modules/graphics/backend/graphics_opengl.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_opengl.cpp
@@ -338,7 +338,14 @@ ShaderHandle Graphics::CreateShader(const ShaderCreateInfo& createInfo)
     ShaderHandle shaderHandle = s->shaderHandlePool.Create();
     s_createInfoCache->shaderCreateInfos.insert(std::make_pair(shaderHandle, createInfo));
 
-    String meta = String("#version 450\n");
+    String meta = String(R""""(
+    #version 450
+    
+    #ifndef OPENGL
+    #define OPENGL
+    #endif // OPENGL
+    )"""");
+
     switch (createInfo.shaderType)
     {
     case ShaderType::VERTEX:

--- a/src/bx/engine/modules/graphics/backend/graphics_opengl.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_opengl.cpp
@@ -343,6 +343,7 @@ ShaderHandle Graphics::CreateShader(const ShaderCreateInfo& createInfo)
     
     #ifndef OPENGL
     #define OPENGL
+    #extension GL_KHR_vulkan_glsl : enable
     #endif // OPENGL
     )"""");
 

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -16,6 +16,7 @@
 
 #include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/conversion.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/compute_pipeline.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
@@ -80,6 +81,8 @@ struct State : NoCopy
     HashMap<ShaderHandle, std::shared_ptr<Shader>> shaders;
     HashMap<GraphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>> graphicsPipelines;
     HashMap<GraphicsPipelineHandle, const List<std::shared_ptr<DescriptorSetLayout>>> graphicsPipelineLayouts;
+    HashMap<ComputePipelineHandle, std::shared_ptr<ComputePipeline>> computePipelines;
+    HashMap<ComputePipelineHandle, const List<std::shared_ptr<DescriptorSetLayout>>> computePipelineLayouts;
     HashMap<BindGroupHandle, std::shared_ptr<DescriptorSet>> bindGroups;
 
     std::shared_ptr<Framebuffer> renderPassFramebuffer = nullptr;
@@ -523,6 +526,7 @@ void Graphics::DestroyGraphicsPipeline(GraphicsPipelineHandle& graphicsPipeline)
     BX_ENSURE(graphicsPipeline);
 
     s->graphicsPipelines.erase(graphicsPipeline);
+    s->graphicsPipelineLayouts.erase(graphicsPipeline);
     s_createInfoCache->graphicsPipelineCreateInfos.erase(graphicsPipeline);
     s->graphicsPipelineHandlePool.Destroy(graphicsPipeline);
 }
@@ -534,10 +538,36 @@ ComputePipelineHandle Graphics::CreateComputePipeline(const ComputePipelineCreat
     ComputePipelineHandle computePipelineHandle = s->computePipelineHandlePool.Create();
     s_createInfoCache->computePipelineCreateInfos.insert(std::make_pair(computePipelineHandle, createInfo));
 
-    /*auto shaderIter = s->shaders.find(createInfo.shader);
-    BX_ENSURE(shaderIter != s->shaders.end());*/
+    List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts{};
+    for (auto& layout : createInfo.layout.bindGroupLayouts)
+    {
+        List<VkDescriptorSetLayoutBinding> bindings{};
+        for (auto& entry : layout.entries)
+        {
+            VkDescriptorSetLayoutBinding binding{};
+            binding.binding = entry.binding;
+            binding.descriptorCount = entry.count.IsSome() ? entry.count.Unwrap() : 1;
+            binding.descriptorType = BindingTypeToVk(entry.type.type);
+            binding.stageFlags = ShaderStageFlagsToVk(entry.visibility);
+            bindings.push_back(binding);
+        }
 
-    BX_FAIL("TODO");
+        std::shared_ptr<DescriptorSetLayout> descriptorSetLayout(new DescriptorSetLayout(Log::Format("{} layout", createInfo.name.c_str()), s->device, bindings));
+        descriptorSetLayouts.push_back(descriptorSetLayout);
+    }
+
+    auto shaderIter = s->shaders.find(createInfo.shader);
+    BX_ENSURE(shaderIter != s->shaders.end());
+
+    std::shared_ptr<ComputePipeline> computePipeline(new ComputePipeline(
+        s->device,
+        shaderIter->second,
+        descriptorSetLayouts));
+    s->computePipelines.insert(std::make_pair(computePipelineHandle, computePipeline));
+
+    s->computePipelineLayouts.emplace(std::piecewise_construct,
+        std::forward_as_tuple(computePipelineHandle),
+        std::forward_as_tuple(std::move(descriptorSetLayouts)));
 
     return computePipelineHandle;
 }
@@ -546,9 +576,10 @@ void Graphics::DestroyComputePipeline(ComputePipelineHandle& computePipeline)
 {
     BX_ENSURE(computePipeline);
 
-   /* s->computePipelines.erase(computePipeline);
+    s->computePipelines.erase(computePipeline);
+    s->computePipelineLayouts.erase(computePipeline);
     s_createInfoCache->computePipelineCreateInfos.erase(computePipeline);
-    s->computePipelineHandlePool.Destroy(computePipeline);*/
+    s->computePipelineHandlePool.Destroy(computePipeline);
 }
 
 BindGroupLayoutHandle Graphics::GetBindGroupLayout(GraphicsPipelineHandle graphicsPipeline, u32 bindGroup)
@@ -596,7 +627,9 @@ BindGroupHandle Graphics::CreateBindGroup(const BindGroupCreateInfo& createInfo)
     }
     else
     {
-        BX_FAIL("TODO");
+        auto layoutIter = s->computePipelineLayouts.find(ComputePipelineHandle{ rawPipeline });
+        BX_ENSURE(layoutIter != s->computePipelineLayouts.end());
+        layout = layoutIter->second[layoutIndex];
     }
 
     std::shared_ptr<DescriptorSet> descriptorSet(new DescriptorSet(createInfo.name, s->device, s->descriptorPool, layout));
@@ -646,6 +679,7 @@ void Graphics::DestroyBindGroup(BindGroupHandle& bindGroup)
 RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descriptor)
 {
     BX_ASSERT(!s->activeRenderPassHandle, "Render pass already active.");
+    BX_ASSERT(!s->activeComputePass, "Compute pass already active.");
 
     u32 width = 0;
     u32 height = 0;
@@ -900,6 +934,7 @@ void Graphics::EndRenderPass(RenderPassHandle& renderPass)
 ComputePassHandle Graphics::BeginComputePass(const ComputePassDescriptor& descriptor)
 {
     BX_ASSERT(!s->activeComputePass, "Compute pass already active.");
+    BX_ASSERT(!s->activeRenderPassHandle, "Render pass already active.");
 
     ComputePassHandle computePassHandle = s->computePassHandlePool.Create();
     //s_createInfoCache->renderPass.insert(std::make_pair(renderPass, descriptor));
@@ -916,9 +951,10 @@ void Graphics::SetComputePipeline(ComputePipelineHandle computePipeline)
 
     s->boundComputePipeline = computePipeline;
 
-    /*auto pipelineIter = s->computePipelines.find(computePipeline);
+    auto pipelineIter = s->computePipelines.find(computePipeline);
     BX_ENSURE(pipelineIter != s->computePipelines.end());
-    auto& pipeline = pipelineIter->second;*/
+
+    s->cmdList->BindComputePipeline(pipelineIter->second);
 
     BX_FAIL("TODO");
 }
@@ -928,7 +964,7 @@ void Graphics::DispatchWorkgroups(u32 x, u32 y, u32 z)
     BX_ASSERT(s->activeComputePass, "No compute pass active.");
     BX_ASSERT(s->boundComputePipeline, "No compute pipeline bound.");
 
-    BX_FAIL("TODO");
+    s->cmdList->Dispatch(x, y, z);
 }
 
 void Graphics::EndComputePass(ComputePassHandle& computePass)
@@ -1079,8 +1115,6 @@ std::shared_ptr<DescriptorSet> GraphicsVulkan::TextureAsDescriptorSet(TextureHan
     auto textureIter = s->textures.find(texture);
     BX_ENSURE(textureIter != s->textures.end());
     descriptorSet->SetImage(0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, textureIter->second, s->sampler);
-
-    //s->cmdList->TrackDescriptorSet(descriptorSet);
 
     return descriptorSet;
 }

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -1009,12 +1009,31 @@ void Graphics::ReadTexture(TextureHandle texture, void* data, const Extend3D& of
 {
     BX_ENSURE(texture);
 
-    /*auto textureIter = s->textures.find(texture);
+    auto textureIter = s->textures.find(texture);
     BX_ENSURE(textureIter != s->textures.end());
+    auto createInfo = GetTextureCreateInfo(texture);
 
-    auto createInfo = GetTextureCreateInfo(texture);*/
+    BX_ASSERT(createInfo.usageFlags & TextureUsageFlags::COPY_SRC, "Texture must be created with TextureUsageFlags::COPY_SRC when reading from.");
 
-    BX_FAIL("TODO");
+    u32 pixelSizeInBytes = SizeOfTextureFormat(createInfo.format);
+    u32 sizeInBytes = size.width * size.height * size.depthOrArrayLayers * pixelSizeInBytes;
+
+    std::shared_ptr<Buffer> readbackBuffer(new Buffer(Log::Format("{} Readback Buffer", createInfo.name), s->device,
+        *s->physicalDevice, VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        static_cast<uint64_t>(sizeInBytes), BufferLocation::CPU_TO_GPU));
+
+    u32 offsetHeight = createInfo.size.height - offset.height;
+
+    auto cmdList = s->cmdQueue->GetCmdList();
+    cmdList->TransitionImageLayout(textureIter->second, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    cmdList->CopyBuffers(textureIter->second, readbackBuffer, VkOffset3D{ (i32)offset.width, (i32)offsetHeight, (i32)offset.depthOrArrayLayers }, VkExtent3D{size.width, size.height, size.depthOrArrayLayers});
+    cmdList->TransitionImageLayout(textureIter->second, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    s->cmdQueue->SubmitCmdList(cmdList, nullptr, {}, {}, {});
+    s->device->WaitIdle();
+
+    void* bufferData = readbackBuffer->Map();
+    memcpy(data, bufferData, sizeInBytes);
+    readbackBuffer->Unmap();
 }
 
 // TODO: obliterate this obomination
@@ -1057,9 +1076,14 @@ std::shared_ptr<DescriptorSet> GraphicsVulkan::TextureAsDescriptorSet(TextureHan
     BX_ENSURE(textureIter != s->textures.end());
     descriptorSet->SetImage(0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, textureIter->second, s->sampler);
 
-    s->cmdList->TrackDescriptorSet(descriptorSet);
+    //s->cmdList->TrackDescriptorSet(descriptorSet);
 
     return descriptorSet;
+}
+
+u32 GraphicsVulkan::GetCurrentFrameIdx()
+{
+    return s->swapchain->GetCurrentFrameIdx();
 }
 
 VkCommandBuffer GraphicsVulkan::RawCommandBuffer()

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -255,6 +255,17 @@ bool Graphics::Initialize()
     s->sampler = std::make_shared<Sampler>("Sampler", s->device, *s->physicalDevice,
         SamplerInfo{});
 
+    BufferCreateInfo bufferCreateInfo{};
+    bufferCreateInfo.name = "Empty Buffer";
+    bufferCreateInfo.size = 1;
+    bufferCreateInfo.usageFlags = BufferUsageFlags::COPY_SRC | BufferUsageFlags::INDEX | BufferUsageFlags::VERTEX | BufferUsageFlags::UNIFORM | BufferUsageFlags::STORAGE;
+    s->emptyBuffer = Graphics::CreateBuffer(bufferCreateInfo);
+
+    TextureCreateInfo textureCreateInfo{};
+    textureCreateInfo.name = "Empty Texture";
+    textureCreateInfo.size = Extend3D(1, 1, 1);
+    textureCreateInfo.usageFlags = TextureUsageFlags::COPY_SRC | TextureUsageFlags::TEXTURE_BINDING | TextureUsageFlags::STORAGE_BINDING;
+
     BuildSwapchain();
     for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
     {
@@ -874,8 +885,8 @@ void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
     auto bindGroupIter = s->bindGroups.find(bindGroup);
     BX_ENSURE(bindGroupIter != s->bindGroups.end());
 
-    // TODO: compute
-    s->cmdList->BindDescriptorSet(bindGroupIter->second, index, VK_PIPELINE_BIND_POINT_GRAPHICS);
+    VkPipelineBindPoint bindPoint = s->activeRenderPassHandle ? VK_PIPELINE_BIND_POINT_GRAPHICS : VK_PIPELINE_BIND_POINT_COMPUTE;
+    s->cmdList->BindDescriptorSet(bindGroupIter->second, index, bindPoint);
 }
 
 void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -9,6 +9,7 @@
 #include "bx/engine/core/memory.hpp"
 #include "bx/engine/core/macros.hpp"
 #include "bx/engine/containers/array.hpp"
+#include "bx/engine/containers/list.hpp"
 
 #include "bx/engine/modules/window.hpp"
 #include "bx/engine/modules/imgui.hpp"
@@ -38,6 +39,8 @@ using namespace Vk;
 #ifdef BX_WINDOW_GLFW_BACKEND
 #include "bx/engine/modules/window/backend/window_glfw.hpp"
 #endif
+
+#include <utility>
 
 constexpr bool ENABLE_VALIDATION =
 #ifdef _DEBUG
@@ -104,10 +107,14 @@ struct State : NoCopy
     HashMap<TextureViewHandle, TextureView> textureViews;
     HashMap<ShaderHandle, std::shared_ptr<Shader>> shaders;
     HashMap<GraphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>> graphicsPipelines;
-    //HashMap<RenderPassInfo, std::shared_ptr<RenderPass>> renderPasses;
+    HashMap<GraphicsPipelineHandle, const List<std::shared_ptr<DescriptorSetLayout>>> graphicsPipelineLayouts;
 
     std::shared_ptr<Framebuffer> renderPassFramebuffer = nullptr;
-    RenderPassHandle activeRenderPass = RenderPassHandle::null;
+    std::shared_ptr<RenderPass> activeRenderPass = nullptr;
+    Optional<RenderPassInfo> activeRenderPassInfo = Optional<RenderPassInfo>::None();
+
+
+    RenderPassHandle activeRenderPassHandle = RenderPassHandle::null;
     ComputePassHandle activeComputePass = ComputePassHandle::null;
     GraphicsPipelineHandle boundGraphicsPipeline = GraphicsPipelineHandle::null;
     ComputePipelineHandle boundComputePipeline = ComputePipelineHandle::null;
@@ -545,6 +552,28 @@ GraphicsPipelineHandle Graphics::CreateGraphicsPipeline(const GraphicsPipelineCr
 
     s->graphicsPipelines.insert(std::make_pair(graphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>{}));
 
+    List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts{};
+    for (auto& layout : createInfo.layout.bindGroupLayouts)
+    {
+        List<VkDescriptorSetLayoutBinding> bindings{};
+        for (auto& entry : layout.entries)
+        {
+            VkDescriptorSetLayoutBinding binding{};
+            binding.binding = entry.binding;
+            binding.descriptorCount = entry.count.IsSome() ? entry.count.Unwrap() : 1;
+            binding.descriptorType = BindingTypeToVk(entry.type.type);
+            binding.stageFlags = ShaderStageFlagsToVk(entry.visibility);
+            bindings.push_back(binding);
+        }
+
+        std::shared_ptr<DescriptorSetLayout> descriptorSetLayout(new DescriptorSetLayout(Log::Format("{} layout", createInfo.name.c_str()), s->device, bindings));
+        descriptorSetLayouts.push_back(descriptorSetLayout);
+    }
+
+    s->graphicsPipelineLayouts.emplace(std::piecewise_construct,
+        std::forward_as_tuple(graphicsPipelineHandle),
+        std::forward_as_tuple(std::move(descriptorSetLayouts)));
+
     return graphicsPipelineHandle;
 }
 
@@ -628,7 +657,7 @@ void Graphics::DestroyBindGroup(BindGroupHandle& bindGroup)
 
 RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descriptor)
 {
-    BX_ASSERT(!s->activeRenderPass, "Render pass already active.");
+    BX_ASSERT(!s->activeRenderPassHandle, "Render pass already active.");
 
     RenderPassInfo renderPassInfo{};
     FramebufferInfo framebufferInfo{};
@@ -664,29 +693,64 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
     RenderPassHandle renderPassHandle = s->renderPassHandlePool.Create();
     s_createInfoCache->renderPassCreateInfos.insert(std::make_pair(renderPassHandle, descriptor));
 
+    s->activeRenderPassInfo = Optional<RenderPassInfo>::Some(renderPassInfo);
     s->renderPassFramebuffer = framebuffer;
-    s->activeRenderPass = renderPassHandle;
+    s->activeRenderPass = framebufferInfo.renderPass;
+    s->activeRenderPassHandle = renderPassHandle;
 
     return renderPassHandle;
 }
 
-void Graphics::SetGraphicsPipeline(GraphicsPipelineHandle graphicsPipeline)
+void Graphics::SetGraphicsPipeline(GraphicsPipelineHandle graphicsPipelineHandle)
 {
-    BX_ASSERT(s->activeRenderPass, "No render pass active.");
-    BX_ENSURE(graphicsPipeline);
+    BX_ASSERT(s->activeRenderPassHandle, "No render pass active.");
+    BX_ENSURE(graphicsPipelineHandle);
 
-    s->boundGraphicsPipeline = graphicsPipeline;
+    s->boundGraphicsPipeline = graphicsPipelineHandle;
 
-    /*auto pipelineIter = s->graphicsPipelines.find(graphicsPipeline);
-    BX_ENSURE(pipelineIter != s->graphicsPipelines.end());
-    auto& pipeline = pipelineIter->second;*/
+    auto& graphicsPipelineIter = s->graphicsPipelines.find(graphicsPipelineHandle);
+    BX_ENSURE(graphicsPipelineIter != s->graphicsPipelines.end());
+    auto& graphicsPipelineMap = graphicsPipelineIter->second;
 
-    BX_FAIL("TODO");
+    std::shared_ptr<GraphicsPipeline> graphicsPipeline;
+    auto& graphicsPipelineMapIter = graphicsPipelineMap.find(s->activeRenderPassInfo.Unwrap());
+    if (graphicsPipelineMapIter == graphicsPipelineMap.end())
+    {
+        auto& createInfo = GetGraphicsPipelineCreateInfo(graphicsPipelineHandle);
+
+        auto& vertexShaderIter = s->shaders.find(createInfo.vertexShader);
+        BX_ENSURE(vertexShaderIter != s->shaders.end());
+        auto& fragmentShaderIter = s->shaders.find(createInfo.fragmentShader);
+        BX_ENSURE(fragmentShaderIter != s->shaders.end());
+        std::shared_ptr<Shader> vertexShader = vertexShaderIter->second;
+        std::shared_ptr<Shader> fragmentShader = fragmentShaderIter->second;
+
+        List<const Shader*> shaders = { vertexShader.get(), fragmentShader.get() };
+        GraphicsPipelineInfo info{};
+        List<PushConstantRange> pc{};
+        
+        auto& layoutIter = s->graphicsPipelineLayouts.find(graphicsPipelineHandle);
+        BX_ENSURE(layoutIter != s->graphicsPipelineLayouts.end());
+
+        graphicsPipeline = std::shared_ptr<GraphicsPipeline>(new GraphicsPipeline(
+            s->device,
+            shaders,
+            s->activeRenderPass,
+            layoutIter->second,
+            pc, info));
+        graphicsPipelineMap.insert(std::make_pair(s->activeRenderPassInfo.Unwrap(), graphicsPipeline));
+    }
+    else
+    {
+        graphicsPipeline = graphicsPipelineMapIter->second;
+    }
+
+    s->cmdList->BindGraphicsPipeline(graphicsPipeline);
 }
 
 void Graphics::SetVertexBuffer(u32 slot, const BufferSlice& bufferSlice)
 {
-    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->activeRenderPassHandle, "No render pass active.");
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ASSERT(slot == 0, "TODO");
     BX_ENSURE(bufferSlice.buffer);
@@ -699,7 +763,7 @@ void Graphics::SetVertexBuffer(u32 slot, const BufferSlice& bufferSlice)
 
 void Graphics::SetIndexBuffer(const BufferSlice& bufferSlice, IndexFormat format)
 {
-    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->activeRenderPassHandle, "No render pass active.");
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ENSURE(bufferSlice.buffer);
 
@@ -713,7 +777,7 @@ void Graphics::SetIndexBuffer(const BufferSlice& bufferSlice, IndexFormat format
 
 void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
 {
-    BX_ASSERT(s->activeRenderPass || s->activeComputePass, "No render pass or compute pass active.");
+    BX_ASSERT(s->activeRenderPassHandle || s->activeComputePass, "No render pass or compute pass active.");
     BX_ENSURE(bindGroup);
 
     auto bindGroupCreateInfoIter = s_createInfoCache->bindGroupCreateInfos.find(bindGroup);
@@ -725,7 +789,7 @@ void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
 
 void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)
 {
-    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->activeRenderPassHandle, "No render pass active.");
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
 
@@ -734,7 +798,7 @@ void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)
 
 void Graphics::DrawIndexed(u32 indexCount, u32 instanceCount)
 {
-    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->activeRenderPassHandle, "No render pass active.");
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ASSERT(s->boundIndexFormat.IsSome(), "No index buffer bound.");
     BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
@@ -744,14 +808,15 @@ void Graphics::DrawIndexed(u32 indexCount, u32 instanceCount)
 
 void Graphics::EndRenderPass(RenderPassHandle& renderPass)
 {
-    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->activeRenderPassHandle, "No render pass active.");
     BX_ENSURE(renderPass);
 
     const RenderPassDescriptor& descriptor = Graphics::GetRenderPassDescriptor(renderPass);
     s->cmdList->EndRenderPass();
 
+    s->activeRenderPassInfo.Reset();
     s->renderPassFramebuffer.reset();
-    s->activeRenderPass = RenderPassHandle::null;
+    s->activeRenderPassHandle = RenderPassHandle::null;
     s->renderPassHandlePool.Destroy(renderPass);
     s_createInfoCache->renderPassCreateInfos.erase(renderPass);
 

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -159,7 +159,7 @@ void BuildSwapchain(HashMap<TextureHandle, TextureCreateInfo>& textureCreateInfo
     Window::GetSize(&width, &height);
 
     s->swapchain.reset();
-    s->swapchain = std::make_unique<Swapchain>(static_cast<u32>(width), static_cast<u32>(height), *s->instance, s->device, *s->physicalDevice);
+    s->swapchain = std::unique_ptr<Swapchain>(new Swapchain(static_cast<u32>(width), static_cast<u32>(height), *s->instance, s->device, *s->physicalDevice));
 
     for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
     {
@@ -195,24 +195,24 @@ void BuildSwapchain(HashMap<TextureHandle, TextureCreateInfo>& textureCreateInfo
 bool Graphics::Initialize()
 {
     s_createInfoCache = std::unique_ptr<CreateInfoCache>(new CreateInfoCache());
-    s = std::make_unique<State>();
+    s = std::unique_ptr<State>(new State());
 
 #ifdef BX_WINDOW_GLFW_BACKEND
     GLFWwindow* glfwWindow = WindowGLFW::GetWindowPtr();
 
-    s->instance = std::make_shared<Instance>((void*)glfwWindow, ENABLE_VALIDATION);
+    s->instance = std::shared_ptr<Instance>(new Instance((void*)glfwWindow, ENABLE_VALIDATION));
 #else
 
     BX_LOGE("Window backend not supported!");
     return false;
 #endif
     
-    s->physicalDevice = std::make_unique<PhysicalDevice>(*s->instance);
-    s->device = std::make_shared<Device>(s->instance, *s->physicalDevice, ENABLE_VALIDATION);
-    s->cmdQueue = std::make_unique<CmdQueue>(s->device, *s->physicalDevice, QueueType::GRAPHICS);
-    s->descriptorPool = std::make_shared<DescriptorPool>(s->device);
-    s->sampler = std::make_shared<Sampler>("Sampler", s->device, *s->physicalDevice,
-        SamplerInfo{});
+    s->physicalDevice = std::unique_ptr<PhysicalDevice>(new PhysicalDevice(*s->instance));
+    s->device = std::shared_ptr<Device>(new Device(s->instance, *s->physicalDevice, ENABLE_VALIDATION));
+    s->cmdQueue = std::unique_ptr<CmdQueue>(new CmdQueue(s->device, *s->physicalDevice, QueueType::GRAPHICS));
+    s->descriptorPool = std::shared_ptr<DescriptorPool>(new DescriptorPool(s->device));
+    s->sampler = std::shared_ptr<Sampler>(new Sampler("Sampler", s->device, *s->physicalDevice,
+        SamplerInfo{}));
 
     BufferCreateInfo bufferCreateInfo{};
     bufferCreateInfo.name = "Empty Buffer";

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -11,6 +11,8 @@
 #include "bx/engine/modules/window.hpp"
 #include "bx/engine/modules/imgui.hpp"
 
+#include "bx/engine/modules/graphics/backend/vulkan/conversion.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
@@ -88,6 +90,9 @@ struct State : NoCopy
     HandlePool<RenderPassApi> renderPassHandlePool;
     HandlePool<ComputePassApi> computePassHandlePool;
     HandlePool<BindGroupApi> bindGroupHandlePool;
+
+    HashMap<BufferHandle, std::shared_ptr<Buffer>> buffers;
+    HashMap<TextureHandle, std::shared_ptr<Image>> textures;
 
     RenderPassHandle activeRenderPass = RenderPassHandle::null;
     ComputePassHandle activeComputePass = ComputePassHandle::null;
@@ -337,7 +342,23 @@ TextureHandle Graphics::CreateTexture(const TextureCreateInfo& createInfo)
     TextureHandle textureHandle = s->textureHandlePool.Create();
     s_createInfoCache->textureCreateInfos.insert(std::make_pair(textureHandle, createInfo.WithoutData()));
 
-    BX_FAIL("TODO");
+    b8 isDepth = IsTextureFormatDepth(createInfo.format);
+    VkImageUsageFlags usage = TextureUsageFlagsToVk(createInfo.usageFlags, isDepth);
+    VkFormat format = TextureFormatToVk(createInfo.format);
+    VkImageType type = TextureDimensionToVk(createInfo.dimension);
+    
+    u32 depth = (createInfo.dimension == TextureDimension::D3) ? createInfo.size.depthOrArrayLayers : 1;
+    u32 arrayLayers = (createInfo.dimension != TextureDimension::D3) ? createInfo.size.depthOrArrayLayers : 1;
+
+    std::shared_ptr<Image> image(new Image(createInfo.name, s->device, *s->physicalDevice,
+        createInfo.size.width, createInfo.size.height, createInfo.mipLevelCount, usage, format, arrayLayers, type, depth));
+    s->textures.emplace(textureHandle, image);
+
+    if (createInfo.data)
+    {
+        // TODO!
+        // WriteTexture(textureHandle, 0, createInfo.data);
+    }
 
     return textureHandle;
 }
@@ -346,13 +367,12 @@ void Graphics::DestroyTexture(TextureHandle& texture)
 {
     BX_ENSURE(texture);
 
-   /* auto textureIter = s->textures.find(texture);
-    BX_ENSURE(textureIter != s->textures.end());*/
-    BX_FAIL("TODO");
+    auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());
 
-    /*s->textures.erase(texture);
+    s->textures.erase(texture);
     s_createInfoCache->textureCreateInfos.erase(texture);
-    s->textureHandlePool.Destroy(texture);*/
+    s->textureHandlePool.Destroy(texture);
 }
 
 TextureViewHandle Graphics::CreateTextureView(TextureHandle texture)
@@ -395,7 +415,18 @@ BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& createInfo)
     BufferHandle bufferHandle = s->bufferHandlePool.Create();
     s_createInfoCache->bufferCreateInfos.insert(std::make_pair(bufferHandle, createInfo.WithoutData()));
 
-    BX_FAIL("TODO");
+    VkBufferUsageFlags usage = BufferUsageFlagsToVk(createInfo.usageFlags);
+    BufferLocation location = IsBufferUsageMappable(createInfo.usageFlags) ? BufferLocation::CPU_TO_GPU : BufferLocation::GPU_ONLY;
+
+    std::shared_ptr<Buffer> buffer(new Buffer(createInfo.name, s->device, *s->physicalDevice, usage, createInfo.size, location));
+    s->buffers.emplace(bufferHandle, buffer);
+
+    // TODO: host visible (mappable) memory doesn't really benefit from using staging buffers, they should directly write to the mappable memory
+    if (createInfo.data)
+    {
+        // TODO!
+        // WriteBuffer(bufferHandle, 0, createInfo.data);
+    }
 
     return bufferHandle;
 }
@@ -404,13 +435,12 @@ void Graphics::DestroyBuffer(BufferHandle& buffer)
 {
     BX_ENSURE(buffer);
 
-    /*auto bufferIter = s->buffers.find(buffer);
-    BX_ENSURE(bufferIter != s->buffers.end());*/
-    BX_FAIL("TODO");
+    auto bufferIter = s->buffers.find(buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());
 
-    /*s->buffers.erase(buffer);
+    s->buffers.erase(buffer);
     s_createInfoCache->bufferCreateInfos.erase(buffer);
-    s->bufferHandlePool.Destroy(buffer);*/
+    s->bufferHandlePool.Destroy(buffer);
 }
 
 ShaderHandle Graphics::CreateShader(const ShaderCreateInfo& createInfo)
@@ -697,8 +727,8 @@ void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data)
     BX_ENSURE(buffer && data);
     BX_ASSERT(offset == 0, "Offset must be 0 for now.");
 
-    /*auto bufferIter = s->buffers.find(buffer);
-    BX_ENSURE(bufferIter != s->buffers.end());*/
+    auto bufferIter = s->buffers.find(buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());
 
     BX_FAIL("TODO");
 }

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -1042,6 +1042,26 @@ ImGui_ImplVulkan_InitInfo GraphicsVulkan::ImGuiInitInfo()
     return info;
 }
 
+std::shared_ptr<DescriptorSet> GraphicsVulkan::TextureAsDescriptorSet(TextureHandle texture)
+{
+    VkDescriptorSetLayoutBinding binding{};
+    binding.binding = 0;
+    binding.descriptorCount = 1;
+    binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    std::shared_ptr<DescriptorSetLayout> layout(new DescriptorSetLayout("Texture As Descriptor Set Layout", s->device, { binding }));
+    std::shared_ptr<DescriptorSet> descriptorSet(new DescriptorSet("Texture As Descriptor Set", s->device, s->descriptorPool, layout));
+    
+    auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());
+    descriptorSet->SetImage(0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, textureIter->second, s->sampler);
+
+    s->cmdList->TrackDescriptorSet(descriptorSet);
+
+    return descriptorSet;
+}
+
 VkCommandBuffer GraphicsVulkan::RawCommandBuffer()
 {
     return s->cmdList->GetCommandBuffer();

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -347,7 +347,7 @@ void Graphics::EndFrame()
         s->cmdList->EndRenderPass();
 
         s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-            VK_ACCESS_SHADER_READ_BIT,
+        //    VK_ACCESS_SHADER_READ_BIT,
             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
         s->cmdList->BeginRenderPass(s->swapchain->GetRenderPass(),
             s->swapchain->GetCurrentFramebuffer(),
@@ -363,7 +363,7 @@ void Graphics::EndFrame()
         s->cmdList->EndRenderPass();
         s->cmdList->TransitionImageLayout(
             s->colorImage, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        //    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
         // Execute all rendering cmds when the image is available
@@ -709,6 +709,7 @@ void Graphics::DestroyBindGroup(BindGroupHandle& bindGroup)
 {
     BX_ENSURE(bindGroup);
 
+    s->bindGroups.erase(bindGroup);
     s_createInfoCache->bindGroupCreateInfos.erase(bindGroup);
     s->bindGroupHandlePool.Destroy(bindGroup);
 }

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -599,8 +599,8 @@ BindGroupHandle Graphics::CreateBindGroup(const BindGroupCreateInfo& createInfo)
             auto bufferIter = s->buffers.find(entry.resource.buffer.buffer);
             BX_ENSURE(bufferIter != s->buffers.end());
 
-            // TODO: read std::shared_ptr<DescriptorSetLayout> layout and cache some stuff to figure out what the buffer type is
-            descriptorSet->SetBuffer(entry.binding, VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, bufferIter->second);
+            VkDescriptorType type = layout->GetDescriptorType(entry.binding);
+            descriptorSet->SetBuffer(entry.binding, type, bufferIter->second);
             break;
         }
         case BindingResourceType::TEXTURE_VIEW:
@@ -608,8 +608,9 @@ BindGroupHandle Graphics::CreateBindGroup(const BindGroupCreateInfo& createInfo)
             auto textureViewIter = s->textureViews.find(entry.resource.textureView);
             BX_ENSURE(textureViewIter != s->textureViews.end());
 
-            // TODO: read std::shared_ptr<DescriptorSetLayout> layout and cache some stuff to figure out what the buffer type is
-            descriptorSet->SetImage(entry.binding, VkDescriptorType::VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, textureViewIter->second.texture, s->sampler);
+            VkDescriptorType type = layout->GetDescriptorType(entry.binding);
+            std::shared_ptr<Sampler> sampler = type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ? s->sampler : nullptr;
+            descriptorSet->SetImage(entry.binding, type, textureViewIter->second.texture, sampler);
             break;
         }
         default:
@@ -826,7 +827,8 @@ void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
     auto bindGroupIter = s->bindGroups.find(bindGroup);
     BX_ENSURE(bindGroupIter != s->bindGroups.end());
 
-    bindGroupIter->second->TransitionResourceStates(s->cmdList);
+    b8 isGraphics = s->activeRenderPassHandle;
+    bindGroupIter->second->TransitionResourceStates(s->cmdList, isGraphics);
 
     VkPipelineBindPoint bindPoint = s->activeRenderPassHandle ? VK_PIPELINE_BIND_POINT_GRAPHICS : VK_PIPELINE_BIND_POINT_COMPUTE;
     s->cmdList->BindDescriptorSet(bindGroupIter->second, index, bindPoint);

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -104,8 +104,9 @@ struct State : NoCopy
     HashMap<TextureViewHandle, TextureView> textureViews;
     HashMap<ShaderHandle, std::shared_ptr<Shader>> shaders;
     HashMap<GraphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>> graphicsPipelines;
-    HashMap<RenderPassInfo, std::shared_ptr<RenderPass>> renderPasses;
+    //HashMap<RenderPassInfo, std::shared_ptr<RenderPass>> renderPasses;
 
+    std::shared_ptr<Framebuffer> renderPassFramebuffer = nullptr;
     RenderPassHandle activeRenderPass = RenderPassHandle::null;
     ComputePassHandle activeComputePass = ComputePassHandle::null;
     GraphicsPipelineHandle boundGraphicsPipeline = GraphicsPipelineHandle::null;
@@ -180,8 +181,11 @@ void BuildRenderTargets()
     renderPassInfo.depthFormat = Optional<VkFormat>::Some(s->depthImage->Format());
     s->renderPass = std::make_shared<RenderPass>("Main Render Pass",
         s->device, renderPassInfo);
-    List<std::shared_ptr<Image>> images{ s->colorImage, s->depthImage };
-    s->framebuffer = std::make_unique<Framebuffer>("Main Framebuffer", s->device, images, s->renderPass);
+
+    FramebufferInfo framebufferInfo{};
+    framebufferInfo.images = { s->colorImage, s->depthImage };
+    framebufferInfo.renderPass = s->renderPass;
+    s->framebuffer = std::make_unique<Framebuffer>("Main Framebuffer", s->device, framebufferInfo);
 }
 
 void BuildDescriptors()
@@ -626,11 +630,41 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
 {
     BX_ASSERT(!s->activeRenderPass, "Render pass already active.");
 
-    BX_FAIL("TODO");
+    RenderPassInfo renderPassInfo{};
+    FramebufferInfo framebufferInfo{};
+    for (auto& colorAttachment : descriptor.colorAttachments)
+    {
+        auto& textureViewIter = s->textureViews.find(colorAttachment.view);
+        BX_ENSURE(textureViewIter != s->textureViews.end());
+        auto& textureCreateInfo = GetTextureCreateInfo(textureViewIter->second.handle);
+
+        framebufferInfo.images.push_back(textureViewIter->second.texture);
+
+        VkFormat format = TextureFormatToVk(textureCreateInfo.format);
+        renderPassInfo.colorFormats.push_back(format);
+    }
+    if (descriptor.depthStencilAttachment.IsSome())
+    {
+        auto& depthAttachment = descriptor.depthStencilAttachment.Unwrap();
+
+        auto& textureViewIter = s->textureViews.find(depthAttachment.view);
+        BX_ENSURE(textureViewIter != s->textureViews.end());
+        auto& textureCreateInfo = GetTextureCreateInfo(textureViewIter->second.handle);
+
+        framebufferInfo.images.push_back(textureViewIter->second.texture);
+
+        VkFormat format = TextureFormatToVk(textureCreateInfo.format);
+        renderPassInfo.depthFormat = Optional<VkFormat>::Some(format);
+    }
+    framebufferInfo.renderPass = RenderPassCache::Get(renderPassInfo);
+    
+    std::shared_ptr<Framebuffer> framebuffer(new Framebuffer("framebuffer", s->device, framebufferInfo));
+    s->cmdList->BeginRenderPass(framebufferInfo.renderPass, *framebuffer, Color::Magenta());
 
     RenderPassHandle renderPassHandle = s->renderPassHandlePool.Create();
     s_createInfoCache->renderPassCreateInfos.insert(std::make_pair(renderPassHandle, descriptor));
 
+    s->renderPassFramebuffer = framebuffer;
     s->activeRenderPass = renderPassHandle;
 
     return renderPassHandle;
@@ -714,8 +748,9 @@ void Graphics::EndRenderPass(RenderPassHandle& renderPass)
     BX_ENSURE(renderPass);
 
     const RenderPassDescriptor& descriptor = Graphics::GetRenderPassDescriptor(renderPass);
-    BX_FAIL("TODO");
+    s->cmdList->EndRenderPass();
 
+    s->renderPassFramebuffer.reset();
     s->activeRenderPass = RenderPassHandle::null;
     s->renderPassHandlePool.Destroy(renderPass);
     s_createInfoCache->renderPassCreateInfos.erase(renderPass);

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -671,7 +671,7 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
 
         framebufferInfo.images.push_back(textureViewIter->second.texture);
         s->cmdList->TransitionImageLayout(textureViewIter->second.texture,
-            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, // TODO: cover non-stencil variants
+            TextureFormatToVkImageLayout(textureCreateInfo.format),
             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
 
         VkFormat format = TextureFormatToVk(textureCreateInfo.format);

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -116,7 +116,6 @@ struct State : NoCopy
     b8 isRenderPassBound = false;
     Optional<RenderPassInfo> activeRenderPassInfo = Optional<RenderPassInfo>::None();
 
-
     RenderPassHandle activeRenderPassHandle = RenderPassHandle::null;
     ComputePassHandle activeComputePass = ComputePassHandle::null;
     GraphicsPipelineHandle boundGraphicsPipeline = GraphicsPipelineHandle::null;
@@ -135,16 +134,7 @@ struct State : NoCopy
     std::unique_ptr<CmdQueue> cmdQueue;
     std::shared_ptr<DescriptorPool> descriptorPool;
     std::unique_ptr<Swapchain> swapchain;
-
-    std::shared_ptr<Image> colorImage;
-    std::shared_ptr<Image> depthImage;
-    std::shared_ptr<Framebuffer> framebuffer;
-    std::shared_ptr<RenderPass> renderPass;
     std::shared_ptr<Sampler> sampler;
-
-    std::shared_ptr<GraphicsPipeline> presentPipeline;
-    std::shared_ptr<DescriptorSetLayout> presentDescriptorSetLayout;
-    Array<std::shared_ptr<DescriptorSet>, Swapchain::MAX_FRAMES_IN_FLIGHT> presentDescriptorSets = { nullptr, nullptr };
 
     std::shared_ptr<Fence> presentFence;
     std::shared_ptr<CmdList> cmdList;
@@ -202,70 +192,6 @@ void BuildSwapchain(HashMap<TextureHandle, TextureCreateInfo>& textureCreateInfo
     }
 }
 
-void BuildRenderTargets()
-{
-    i32 width, height;
-    Window::GetSize(&width, &height);
-
-    s->colorImage = std::make_shared<Image>(
-        "Color Image", s->device, *s->physicalDevice, width, height, 1,
-        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
-        VK_IMAGE_USAGE_STORAGE_BIT,
-        VK_FORMAT_R16G16B16A16_SFLOAT);
-    s->depthImage = std::make_shared<Image>(
-        "Depth Image", s->device, *s->physicalDevice, width, height, 1,
-        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-        VK_FORMAT_D24_UNORM_S8_UINT);
-
-    RenderPassInfo renderPassInfo{};
-    renderPassInfo.colorFormats = { s->colorImage->Format() };
-    renderPassInfo.depthFormat = Optional<VkFormat>::Some(s->depthImage->Format());
-    s->renderPass = std::make_shared<RenderPass>("Main Render Pass",
-        s->device, renderPassInfo);
-
-    FramebufferInfo framebufferInfo{};
-    framebufferInfo.images = { s->colorImage, s->depthImage };
-    framebufferInfo.renderPass = s->renderPass;
-    s->framebuffer = std::make_shared<Framebuffer>("Main Framebuffer", s->device, framebufferInfo);
-}
-
-void BuildDescriptors()
-{
-    VkDescriptorSetLayoutBinding presentBinding0{};
-    presentBinding0.binding = 0;
-    presentBinding0.descriptorCount = 1;
-    presentBinding0.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    presentBinding0.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-
-    s->presentDescriptorSetLayout = std::make_shared<DescriptorSetLayout>(
-        "Present Descriptor Set Layout 0",
-        s->device, List<VkDescriptorSetLayoutBinding>{ presentBinding0 });
-
-    for (size_t i = 0; i < s->presentDescriptorSets.size(); i++) {
-        s->presentDescriptorSets[i] = std::make_shared<DescriptorSet>(
-            "Present Descriptor Set 0",
-            s->device, s->descriptorPool, s->presentDescriptorSetLayout);
-    }
-}
-
-void BuildPipelines()
-{
-    std::shared_ptr<Shader> presentVertexShader =
-        std::make_shared<Shader>("present vert", s->device, VK_SHADER_STAGE_VERTEX_BIT, PRESENT_VERT_SRC);
-    std::shared_ptr<Shader> presentFragmentShader =
-        std::make_shared<Shader>("present frag", s->device, VK_SHADER_STAGE_FRAGMENT_BIT, PRESENT_FRAG_SRC);
-
-    GraphicsPipelineInfo presentInfo{};
-    presentInfo.ignoreDepth = true;
-    presentInfo.inputVertices = false;
-    std::vector<const Shader*> presentShaders = { presentVertexShader.get(),
-                                                 presentFragmentShader.get() };
-    s->presentPipeline = std::make_shared<GraphicsPipeline>(
-        s->device, presentShaders, s->swapchain->GetRenderPass(),
-        std::vector<std::shared_ptr<DescriptorSetLayout>>{s->presentDescriptorSetLayout},
-        std::vector<PushConstantRange>{}, presentInfo);
-}
-
 bool Graphics::Initialize()
 {
     s_createInfoCache = std::unique_ptr<CreateInfoCache>(new CreateInfoCache());
@@ -300,9 +226,6 @@ bool Graphics::Initialize()
     textureCreateInfo.usageFlags = TextureUsageFlags::COPY_SRC | TextureUsageFlags::TEXTURE_BINDING | TextureUsageFlags::STORAGE_BINDING;
 
     BuildSwapchain(s_createInfoCache->textureCreateInfos);
-    BuildRenderTargets();
-    BuildDescriptors();
-    BuildPipelines();
 
     return true;
 }
@@ -328,8 +251,6 @@ void Graphics::NewFrame()
             s->device->WaitIdle();
 
             BuildSwapchain(s_createInfoCache->textureCreateInfos);
-            BuildRenderTargets();
-            BuildPipelines();
         }
 
         s->presentFence = s->swapchain->NextImage();
@@ -350,31 +271,11 @@ void Graphics::EndFrame()
 
     if (Window::IsActive())
     {
-        // TODO: all rendering can happen before the image is available if we create a seperate present blit pipeline
-        // This can also act as a hdr to sdr conversion and enable us to render in hdr
-
-        Rect2D swapchainExtent = s->swapchain->Extent();
         size_t currentFrame = static_cast<size_t>(s->swapchain->GetCurrentFrameIdx());
 
-        s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-        s->cmdList->TransitionImageLayout(s->depthImage, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
+#ifdef BX_EDITOR_BUILD
+        Rect2D swapchainExtent = s->swapchain->Extent();
 
-        // Swapchain present pass
-        s->cmdList->BeginRenderPass(s->renderPass, s->framebuffer,
-            Color(0.6f, 0.8f, 1.0f, 1.0f));
-        Rect2D imgExtent(static_cast<float>(s->colorImage->Width()),
-            static_cast<float>(s->colorImage->Height()));
-        s->cmdList->SetScissor(imgExtent);
-        s->cmdList->SetViewport(imgExtent);
-        // TODO: render da shit
-        s->cmdList->EndRenderPass();
-        ResourceStateTracker::ApplyImplicitImageTransition(*s->colorImage,
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-
-        s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
         s->cmdList->TransitionImageLayout(s->swapchain->GetImage(currentFrame),
             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
@@ -384,19 +285,11 @@ void Graphics::EndFrame()
             Color(0.1f, 0.1f, 0.1f, 1.0f));
         s->cmdList->SetScissor(swapchainExtent);
         s->cmdList->SetViewport(swapchainExtent);
-        s->cmdList->BindGraphicsPipeline(s->presentPipeline);
-        s->presentDescriptorSets[currentFrame]->SetImage(
-            0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, s->colorImage, s->sampler);
-        s->cmdList->BindDescriptorSet(s->presentDescriptorSets[currentFrame], 0);
-        s->cmdList->Draw(3);
         ImGuiImpl::EndFrame();
         s->cmdList->EndRenderPass();
         ResourceStateTracker::ApplyImplicitImageTransition(*s->swapchain->GetImage(currentFrame),
             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-
-        s->cmdList->TransitionImageLayout(
-            s->colorImage, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+#endif
 
         s->cmdList->TransitionImageLayout(s->swapchain->GetImage(currentFrame),
             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -50,35 +50,6 @@ true;
 false;
 #endif
 
-static String PRESENT_VERT_SRC = R"""(
-#version 450
-#extension GL_ARB_separate_shader_objects : enable
-
-layout(location = 0) out vec2 fragTexCoord;
-
-void main() {
-    fragTexCoord = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
-    gl_Position = vec4(fragTexCoord * 2.0f + -1.0f, 0.0f, 1.0f);
-    fragTexCoord.y = -fragTexCoord.y;
-}
-)""";
-
-static String PRESENT_FRAG_SRC = R"""(
-#version 450
-#extension GL_ARB_separate_shader_objects : enable
-
-layout(location = 0) in vec2 fragTexCoord;
-
-layout(location = 0) out vec4 outColor;
-
-layout(binding = 0) uniform sampler2D colorImage;
-
-void main() {
-    vec3 color = texture(colorImage, fragTexCoord).rgb;
-    outColor = vec4(color, 1.0);
-}
-)""";
-
 struct TextureView
 {
     TextureHandle handle;
@@ -146,7 +117,7 @@ struct RenderPassCache : public LazyInitMap<RenderPassCache, std::shared_ptr<Ren
 {
     RenderPassCache(const RenderPassInfo& args)
     {
-        data = std::shared_ptr<RenderPass>(new RenderPass("render pass", s->device, args));
+        data = std::shared_ptr<RenderPass>(new RenderPass("Render Pass", s->device, args));
     }
 };
 
@@ -334,7 +305,6 @@ TextureViewHandle Graphics::GetSwapchainColorTargetView()
 
 TextureHandle Graphics::CreateTexture(const TextureCreateInfo& _createInfo)
 {
-    // TODO: HACKS HACKS HACKS
     TextureCreateInfo createInfo = _createInfo;
     createInfo.usageFlags = createInfo.usageFlags | TextureUsageFlags::COPY_DST;
 
@@ -357,7 +327,6 @@ TextureHandle Graphics::CreateTexture(const TextureCreateInfo& _createInfo)
 
     if (createInfo.data)
     {
-        // TODO!
         WriteTexture(textureHandle, createInfo.data, Extend3D(0, 0, 0), createInfo.size);
     }
 
@@ -415,9 +384,11 @@ void Graphics::DestroySampler(SamplerHandle& sampler)
 
 BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& _createInfo)
 {
-    // TODO: HACKS HACKS HACKS
     BufferCreateInfo createInfo = _createInfo;
-    createInfo.usageFlags = createInfo.usageFlags | BufferUsageFlags::COPY_DST;
+
+    b8 isMappable = IsBufferUsageMappable(createInfo.usageFlags);
+    if (!isMappable)
+        createInfo.usageFlags = createInfo.usageFlags | BufferUsageFlags::COPY_DST;
 
     BX_ENSURE(ValidateBufferCreateInfo(createInfo));
 
@@ -425,16 +396,23 @@ BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& _createInfo)
     s_createInfoCache->bufferCreateInfos.insert(std::make_pair(bufferHandle, createInfo.WithoutData()));
 
     VkBufferUsageFlags usage = BufferUsageFlagsToVk(createInfo.usageFlags);
-    BufferLocation location = IsBufferUsageMappable(createInfo.usageFlags) ? BufferLocation::CPU_TO_GPU : BufferLocation::GPU_ONLY;
+    BufferLocation location = isMappable ? BufferLocation::CPU_TO_GPU : BufferLocation::GPU_ONLY;
 
     std::shared_ptr<Buffer> buffer(new Buffer(createInfo.name, s->device, *s->physicalDevice, usage, createInfo.size, location));
     s->buffers.emplace(bufferHandle, buffer);
 
-    // TODO: host visible (mappable) memory doesn't really benefit from using staging buffers, they should directly write to the mappable memory
     if (createInfo.data)
     {
-        // TODO!
-        WriteBuffer(bufferHandle, 0, createInfo.data);
+        if (!isMappable)
+        {
+            WriteBuffer(bufferHandle, 0, createInfo.data);
+        }
+        else
+        {
+            void* bufferData = buffer->Map();
+            memcpy(bufferData, createInfo.data, createInfo.size);
+            buffer->Unmap();
+        }
     }
 
     return bufferHandle;

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -112,6 +112,7 @@ struct State : NoCopy
 
     std::shared_ptr<Framebuffer> renderPassFramebuffer = nullptr;
     std::shared_ptr<RenderPass> activeRenderPass = nullptr;
+    b8 isRenderPassBound = false;
     Optional<RenderPassInfo> activeRenderPassInfo = Optional<RenderPassInfo>::None();
 
 
@@ -136,7 +137,7 @@ struct State : NoCopy
 
     std::shared_ptr<Image> colorImage;
     std::shared_ptr<Image> depthImage;
-    std::unique_ptr<Framebuffer> framebuffer;
+    std::shared_ptr<Framebuffer> framebuffer;
     std::shared_ptr<RenderPass> renderPass;
     std::shared_ptr<Sampler> sampler;
 
@@ -193,7 +194,7 @@ void BuildRenderTargets()
     FramebufferInfo framebufferInfo{};
     framebufferInfo.images = { s->colorImage, s->depthImage };
     framebufferInfo.renderPass = s->renderPass;
-    s->framebuffer = std::make_unique<Framebuffer>("Main Framebuffer", s->device, framebufferInfo);
+    s->framebuffer = std::make_shared<Framebuffer>("Main Framebuffer", s->device, framebufferInfo);
 }
 
 void BuildDescriptors()
@@ -336,7 +337,7 @@ void Graphics::EndFrame()
         size_t currentFrame = static_cast<size_t>(s->swapchain->GetCurrentFrameIdx());
 
         // Swapchain present pass
-        s->cmdList->BeginRenderPass(s->renderPass, *s->framebuffer,
+        s->cmdList->BeginRenderPass(s->renderPass, s->framebuffer,
             Color(0.6f, 0.8f, 1.0f, 1.0f));
         Rect2D imgExtent(static_cast<float>(s->colorImage->Width()),
             static_cast<float>(s->colorImage->Height()));
@@ -546,12 +547,13 @@ void Graphics::DestroyShader(ShaderHandle& shader)
 {
     BX_ENSURE(shader);
 
-    auto shaderIter = s->shaders.find(shader);
+    // Graphics pipelines are created on demand during SetGraphicsPipeline, immediately destroying shaders is therefore not valid
+    /*auto shaderIter = s->shaders.find(shader);
     BX_ENSURE(shaderIter != s->shaders.end());
 
     s->shaders.erase(shader);
     s_createInfoCache->shaderCreateInfos.erase(shader);
-    s->shaderHandlePool.Destroy(shader);
+    s->shaderHandlePool.Destroy(shader);*/
 }
 
 GraphicsPipelineHandle Graphics::CreateGraphicsPipeline(const GraphicsPipelineCreateInfo& createInfo)
@@ -761,7 +763,6 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
     framebufferInfo.renderPass = RenderPassCache::Get(renderPassInfo);
     
     std::shared_ptr<Framebuffer> framebuffer(new Framebuffer("framebuffer", s->device, framebufferInfo));
-    s->cmdList->BeginRenderPass(framebufferInfo.renderPass, *framebuffer, Color::Magenta());
     s->cmdList->SetViewport(Rect2D(width, height));
     s->cmdList->SetScissor(Rect2D(width, height));
 
@@ -882,8 +883,16 @@ void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
     BX_ASSERT(s->activeRenderPassHandle || s->activeComputePass, "No render pass or compute pass active.");
     BX_ENSURE(bindGroup);
 
+    if (s->isRenderPassBound)
+    {
+        s->cmdList->EndRenderPass();
+        s->isRenderPassBound = false;
+    }
+
     auto bindGroupIter = s->bindGroups.find(bindGroup);
     BX_ENSURE(bindGroupIter != s->bindGroups.end());
+
+    bindGroupIter->second->TransitionResourceStates(s->cmdList);
 
     VkPipelineBindPoint bindPoint = s->activeRenderPassHandle ? VK_PIPELINE_BIND_POINT_GRAPHICS : VK_PIPELINE_BIND_POINT_COMPUTE;
     s->cmdList->BindDescriptorSet(bindGroupIter->second, index, bindPoint);
@@ -895,6 +904,12 @@ void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
 
+    if (!s->isRenderPassBound)
+    {
+        s->cmdList->BeginRenderPass(s->activeRenderPass, s->renderPassFramebuffer, Color::Magenta());
+        s->isRenderPassBound = true;
+    }
+
     s->cmdList->Draw(vertexCount, instanceCount, firstVertex);
 }
 
@@ -905,6 +920,12 @@ void Graphics::DrawIndexed(u32 indexCount, u32 instanceCount)
     BX_ASSERT(s->boundIndexFormat.IsSome(), "No index buffer bound.");
     BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
 
+    if (!s->isRenderPassBound)
+    {
+        s->cmdList->BeginRenderPass(s->activeRenderPass, s->renderPassFramebuffer, Color::Magenta());
+        s->isRenderPassBound = true;
+    }
+
     s->cmdList->DrawElements(indexCount, instanceCount);
 }
 
@@ -914,7 +935,11 @@ void Graphics::EndRenderPass(RenderPassHandle& renderPass)
     BX_ENSURE(renderPass);
 
     const RenderPassDescriptor& descriptor = Graphics::GetRenderPassDescriptor(renderPass);
-    s->cmdList->EndRenderPass();
+    if (s->isRenderPassBound)
+    {
+        s->cmdList->EndRenderPass();
+        s->isRenderPassBound = false;
+    }
 
     s->activeRenderPassInfo.Reset();
     s->renderPassFramebuffer.reset();

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -725,8 +725,35 @@ void Graphics::SetGraphicsPipeline(GraphicsPipelineHandle graphicsPipelineHandle
         std::shared_ptr<Shader> vertexShader = vertexShaderIter->second;
         std::shared_ptr<Shader> fragmentShader = fragmentShaderIter->second;
 
+        List<VkVertexInputBindingDescription> vertexBindingDescriptions{};
+        for (u32 i = 0; i < createInfo.vertexBuffers.size(); i++)
+        {
+            VkVertexInputBindingDescription bindingDescription{};
+            bindingDescription.binding = i;
+            bindingDescription.stride = createInfo.vertexBuffers[i].stride;
+            bindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+            vertexBindingDescriptions.push_back(bindingDescription);
+        }
+
+        List<VkVertexInputAttributeDescription> vertexAttributeDescriptions{};
+        for (u32 i = 0; i < createInfo.vertexBuffers.size(); i++)
+        {
+            for (auto& attribute : createInfo.vertexBuffers[i].attributes)
+            {
+                VkVertexInputAttributeDescription attributeDescription;
+                attributeDescription.binding = i;
+                attributeDescription.location = attribute.location;
+                attributeDescription.format = VertexFormatToVk(attribute.format);
+                attributeDescription.offset = attribute.offset;
+                vertexAttributeDescriptions.push_back(attributeDescription);
+            }
+        }
+
         List<const Shader*> shaders = { vertexShader.get(), fragmentShader.get() };
-        GraphicsPipelineInfo info{};
+        GraphicsPipelineInfo info{}; // TODO!
+        info.vertexBindingDescriptions = vertexBindingDescriptions;
+        info.vertexAttributeDescriptions = vertexAttributeDescriptions;
+
         List<PushConstantRange> pc{};
         
         auto& layoutIter = s->graphicsPipelineLayouts.find(graphicsPipelineHandle);

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -14,6 +14,7 @@
 #include "bx/engine/modules/window.hpp"
 #include "bx/engine/modules/imgui.hpp"
 
+#include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/conversion.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
@@ -161,13 +162,43 @@ struct RenderPassCache : public LazyInitMap<RenderPassCache, std::shared_ptr<Ren
 template<>
 HashMap<RenderPassInfo, std::unique_ptr<RenderPassCache>> LazyInitMap<RenderPassCache, std::shared_ptr<RenderPass>, RenderPassInfo>::cache = {};
 
-void BuildSwapchain()
+void BuildSwapchain(HashMap<TextureHandle, TextureCreateInfo>& textureCreateInfos)
 {
     i32 width, height;
     Window::GetSize(&width, &height);
 
     s->swapchain.reset();
     s->swapchain = std::make_unique<Swapchain>(static_cast<u32>(width), static_cast<u32>(height), *s->instance, s->device, *s->physicalDevice);
+
+    for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
+    {
+        if (s->swapchainColorTargets[i])
+        {
+            Graphics::DestroyTexture(s->swapchainColorTargets[i]);
+        }
+
+        if (s->swapchainColorTargetViews[i])
+        {
+            Graphics::DestroyTextureView(s->swapchainColorTargetViews[i]);
+        }
+    }
+
+    for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
+    {
+        TextureHandle textureHandle = s->textureHandlePool.Create();
+        TextureViewHandle textureViewHandle = s->textureViewHandlePool.Create();
+        textureCreateInfos.insert(std::make_pair(textureHandle, s->swapchain->GetImageCreateInfo()));
+
+        std::shared_ptr<Image> image = s->swapchain->GetImage(i);
+        TextureView textureView{};
+        textureView.handle = textureHandle;
+        textureView.texture = image;
+
+        s->textures.emplace(textureHandle, image);
+        s->textureViews.emplace(textureViewHandle, textureView);
+        s->swapchainColorTargets[i] = textureHandle;
+        s->swapchainColorTargetViews[i] = textureViewHandle;
+    }
 }
 
 void BuildRenderTargets()
@@ -267,18 +298,7 @@ bool Graphics::Initialize()
     textureCreateInfo.size = Extend3D(1, 1, 1);
     textureCreateInfo.usageFlags = TextureUsageFlags::COPY_SRC | TextureUsageFlags::TEXTURE_BINDING | TextureUsageFlags::STORAGE_BINDING;
 
-    BuildSwapchain();
-    for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
-    {
-        TextureHandle textureHandle = s->textureHandlePool.Create();
-        s_createInfoCache->textureCreateInfos.insert(std::make_pair(textureHandle, s->swapchain->GetImageCreateInfo()));
-
-        std::shared_ptr<Image> image = s->swapchain->GetImage(i);
-        s->textures.emplace(textureHandle, image);
-        s->swapchainColorTargets[i] = textureHandle;
-        s->swapchainColorTargetViews[i] = TextureViewHandle{ textureHandle.id };
-    }
-    
+    BuildSwapchain(s_createInfoCache->textureCreateInfos);
     BuildRenderTargets();
     BuildDescriptors();
     BuildPipelines();
@@ -302,18 +322,11 @@ void Graphics::NewFrame()
 
     if (Window::IsActive())
     {
-        if (Window::WasResized())
+        if (Window::WasResized() && false)
         {
-            BuildSwapchain();
-            for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
-            {
-                TextureHandle textureHandle = s->textureHandlePool.Create();
-                s_createInfoCache->textureCreateInfos.insert(std::make_pair(textureHandle, s->swapchain->GetImageCreateInfo()));
+            s->device->WaitIdle();
 
-                std::shared_ptr<Image> image = s->swapchain->GetImage(i);
-                s->textures.emplace(textureHandle, image);
-            }
-
+            BuildSwapchain(s_createInfoCache->textureCreateInfos);
             BuildRenderTargets();
             BuildPipelines();
         }
@@ -345,10 +358,16 @@ void Graphics::EndFrame()
         s->cmdList->SetViewport(imgExtent);
         // TODO: render da shit
         s->cmdList->EndRenderPass();
+        ResourceStateTracker::ApplyImplicitImageTransition(*s->colorImage,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
         s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
         //    VK_ACCESS_SHADER_READ_BIT,
             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        s->cmdList->TransitionImageLayout(s->swapchain->GetImage(currentFrame),
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+
         s->cmdList->BeginRenderPass(s->swapchain->GetRenderPass(),
             s->swapchain->GetCurrentFramebuffer(),
             Color(0.1f, 0.1f, 0.1f, 1.0f));
@@ -361,10 +380,17 @@ void Graphics::EndFrame()
         s->cmdList->Draw(3);
         ImGuiImpl::EndFrame();
         s->cmdList->EndRenderPass();
+        ResourceStateTracker::ApplyImplicitImageTransition(*s->swapchain->GetImage(currentFrame),
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
         s->cmdList->TransitionImageLayout(
             s->colorImage, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
         //    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+
+        s->cmdList->TransitionImageLayout(s->swapchain->GetImage(currentFrame),
+            VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);// VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
         // Execute all rendering cmds when the image is available
         List<Semaphore*> waitSemaphores{ &s->swapchain->GetImageAvailableSemaphore() };
@@ -376,6 +402,8 @@ void Graphics::EndFrame()
 
         // Present when rendering is finished, indicated by the `presentSignalSemaphores`
         s->swapchain->Present(*s->cmdQueue, *s->presentFence, presentSignalSemaphores);
+        ResourceStateTracker::ApplyImplicitImageTransition(*s->swapchain->GetImage(currentFrame),
+            VK_IMAGE_LAYOUT_UNDEFINED);
     }
 
     s->cmdList.reset();
@@ -730,6 +758,9 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
         auto& textureCreateInfo = GetTextureCreateInfo(textureViewIter->second.handle);
 
         framebufferInfo.images.push_back(textureViewIter->second.texture);
+        s->cmdList->TransitionImageLayout(textureViewIter->second.texture,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
         VkFormat format = TextureFormatToVk(textureCreateInfo.format);
         renderPassInfo.colorFormats.push_back(format);
@@ -750,6 +781,9 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
         auto& textureCreateInfo = GetTextureCreateInfo(textureViewIter->second.handle);
 
         framebufferInfo.images.push_back(textureViewIter->second.texture);
+        s->cmdList->TransitionImageLayout(textureViewIter->second.texture,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, // TODO: cover non-stencil variants
+            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
 
         VkFormat format = TextureFormatToVk(textureCreateInfo.format);
         renderPassInfo.depthFormat = Optional<VkFormat>::Some(format);

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -104,8 +104,8 @@ struct State : NoCopy
     BufferHandle emptyBuffer = BufferHandle::null;
     TextureHandle emptyTexture = TextureHandle::null;
 
-    TextureHandle swapchainColorTarget = TextureHandle::null;
-    TextureViewHandle swapchainColorTargetView = TextureViewHandle::null;
+    Array<TextureHandle, Swapchain::MAX_FRAMES_IN_FLIGHT> swapchainColorTargets = {};
+    Array<TextureViewHandle, Swapchain::MAX_FRAMES_IN_FLIGHT> swapchainColorTargetViews = {};
 
     std::shared_ptr<Instance> instance;
     std::unique_ptr<PhysicalDevice> physicalDevice;
@@ -205,16 +205,13 @@ bool Graphics::Initialize()
 #ifdef BX_WINDOW_GLFW_BACKEND
     GLFWwindow* glfwWindow = WindowGLFW::GetWindowPtr();
 
-    uint32_t extensionsCount = 0;
-    const char** extensions = glfwGetRequiredInstanceExtensions(&extensionsCount);
-
+    s->instance = std::make_shared<Instance>((void*)glfwWindow, ENABLE_VALIDATION);
 #else
 
     BX_LOGE("Window backend not supported!");
     return false;
 #endif
-
-    s->instance = std::make_shared<Instance>((void*)glfwWindow, ENABLE_VALIDATION);
+    
     s->physicalDevice = std::make_unique<PhysicalDevice>(*s->instance);
     s->device = std::make_shared<Device>(s->instance, *s->physicalDevice, ENABLE_VALIDATION);
     s->cmdQueue = std::make_unique<CmdQueue>(s->device, *s->physicalDevice, QueueType::GRAPHICS);
@@ -223,6 +220,18 @@ bool Graphics::Initialize()
         SamplerInfo{});
 
     BuildSwapchain();
+    for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
+    {
+        TextureHandle textureHandle = s->textureHandlePool.Create();
+        s_createInfoCache->textureCreateInfos.insert(std::make_pair(textureHandle, s->swapchain->GetImageCreateInfo()));
+
+        std::shared_ptr<Image> image = s->swapchain->GetImage(i);
+        s->textures.emplace(textureHandle, image);
+        s->swapchainColorTargets[i] = textureHandle;
+        s->swapchainColorTargetViews[i] = TextureViewHandle{ textureHandle.id };
+    }
+    
+
     BuildRenderTargets();
     BuildDescriptors();
     BuildPipelines();
@@ -249,6 +258,15 @@ void Graphics::NewFrame()
         if (Window::WasResized())
         {
             BuildSwapchain();
+            for (u32 i = 0; i < Swapchain::MAX_FRAMES_IN_FLIGHT; i++)
+            {
+                TextureHandle textureHandle = s->textureHandlePool.Create();
+                s_createInfoCache->textureCreateInfos.insert(std::make_pair(textureHandle, s->swapchain->GetImageCreateInfo()));
+
+                std::shared_ptr<Image> image = s->swapchain->GetImage(i);
+                s->textures.emplace(textureHandle, image);
+            }
+
             BuildRenderTargets();
             BuildPipelines();
         }
@@ -328,12 +346,12 @@ const TextureHandle& Graphics::EmptyTexture()
 
 TextureHandle Graphics::GetSwapchainColorTarget()
 {
-    return s->swapchainColorTarget;
+    return s->swapchainColorTargets[s->swapchain->GetCurrentFrameIdx()];
 }
 
 TextureViewHandle Graphics::GetSwapchainColorTargetView()
 {
-    return s->swapchainColorTargetView;
+    return s->swapchainColorTargetViews[s->swapchain->GetCurrentFrameIdx()];
 }
 
 TextureHandle Graphics::CreateTexture(const TextureCreateInfo& createInfo)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -217,7 +217,7 @@ void Graphics::NewFrame()
 
     if (Window::IsActive())
     {
-        if (Window::WasResized() && false)
+        if (Window::WasResized())
         {
             s->device->WaitIdle();
 
@@ -225,11 +225,11 @@ void Graphics::NewFrame()
         }
 
         s->presentFence = s->swapchain->NextImage();
-
-        // All cmds of the entire frame will be recorded into a single cmd list
-        // This is because we designed the graphics module api to act like it's immediate
-        s->cmdList = s->cmdQueue->GetCmdList();
     }
+
+    // All cmds of the entire frame will be recorded into a single cmd list
+    // This is because we designed the graphics module api to act like it's immediate
+    s->cmdList = s->cmdQueue->GetCmdList();
 }
 
 void Graphics::EndFrame()
@@ -278,6 +278,10 @@ void Graphics::EndFrame()
         s->swapchain->Present(*s->cmdQueue, *s->presentFence, presentSignalSemaphores);
         ResourceStateTracker::ApplyImplicitImageTransition(*s->swapchain->GetImage(currentFrame),
             VK_IMAGE_LAYOUT_UNDEFINED);
+    }
+    else
+    {
+        ImGuiImpl::EndFrame();
     }
 
     s->cmdList.reset();

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -2,6 +2,8 @@
 
 #include "bx/engine/modules/graphics/type_validation.hpp"
 
+#include "bx/framework/systems/renderer/lazy_init.hpp"
+
 #include "bx/engine/core/file.hpp"
 #include "bx/engine/core/profiler.hpp"
 #include "bx/engine/core/memory.hpp"
@@ -73,6 +75,12 @@ void main() {
 }
 )""";
 
+struct TextureView
+{
+    TextureHandle handle;
+    std::shared_ptr<Image> texture;
+};
+
 struct State : NoCopy
 {
     ~State()
@@ -93,7 +101,10 @@ struct State : NoCopy
 
     HashMap<BufferHandle, std::shared_ptr<Buffer>> buffers;
     HashMap<TextureHandle, std::shared_ptr<Image>> textures;
+    HashMap<TextureViewHandle, TextureView> textureViews;
     HashMap<ShaderHandle, std::shared_ptr<Shader>> shaders;
+    HashMap<GraphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>> graphicsPipelines;
+    HashMap<RenderPassInfo, std::shared_ptr<RenderPass>> renderPasses;
 
     RenderPassHandle activeRenderPass = RenderPassHandle::null;
     ComputePassHandle activeComputePass = ComputePassHandle::null;
@@ -129,6 +140,17 @@ struct State : NoCopy
 };
 static std::unique_ptr<State> s;
 
+struct RenderPassCache : public LazyInitMap<RenderPassCache, std::shared_ptr<RenderPass>, RenderPassInfo>
+{
+    RenderPassCache(const RenderPassInfo& args)
+    {
+        data = std::shared_ptr<RenderPass>(new RenderPass("render pass", s->device, args));
+    }
+};
+
+template<>
+HashMap<RenderPassInfo, std::unique_ptr<RenderPassCache>> LazyInitMap<RenderPassCache, std::shared_ptr<RenderPass>, RenderPassInfo>::cache = {};
+
 void BuildSwapchain()
 {
     i32 width, height;
@@ -153,9 +175,11 @@ void BuildRenderTargets()
         VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
         VK_FORMAT_D24_UNORM_S8_UINT);
 
+    RenderPassInfo renderPassInfo{};
+    renderPassInfo.colorFormats = { s->colorImage->Format() };
+    renderPassInfo.depthFormat = Optional<VkFormat>::Some(s->depthImage->Format());
     s->renderPass = std::make_shared<RenderPass>("Main Render Pass",
-        s->device, List<VkFormat>{ s->colorImage->Format() },
-        Optional<VkFormat>::Some(s->depthImage->Format()));
+        s->device, renderPassInfo);
     List<std::shared_ptr<Image>> images{ s->colorImage, s->depthImage };
     s->framebuffer = std::make_unique<Framebuffer>("Main Framebuffer", s->device, images, s->renderPass);
 }
@@ -400,10 +424,14 @@ TextureViewHandle Graphics::CreateTextureView(TextureHandle texture)
 
     TextureViewHandle textureViewHandle = s->textureViewHandlePool.Create();
 
-    /*auto textureIter = s->textures.find(texture);
-    BX_ENSURE(textureIter != s->textures.end());*/
+    auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());
 
-    BX_FAIL("TODO");
+    TextureView textureView;
+    textureView.handle = texture;
+    textureView.texture = textureIter->second;
+
+    s->textureViews.insert(std::make_pair(textureViewHandle, textureView));
 
     return textureViewHandle;
 }
@@ -412,8 +440,8 @@ void Graphics::DestroyTextureView(TextureViewHandle& textureView)
 {
     BX_ENSURE(textureView);
 
-    /*s->textureViews.erase(textureView);
-    s->textureViewHandlePool.Destroy(textureView);*/
+    s->textureViews.erase(textureView);
+    s->textureViewHandlePool.Destroy(textureView);
 }
 
 SamplerHandle Graphics::CreateSampler(const SamplerCreateInfo& create)
@@ -496,12 +524,12 @@ void Graphics::DestroyShader(ShaderHandle& shader)
 {
     BX_ENSURE(shader);
 
-    /*auto shaderIter = s->shaders.find(shader);
-    BX_ENSURE(shaderIter != s->shaders.end());*/
+    auto shaderIter = s->shaders.find(shader);
+    BX_ENSURE(shaderIter != s->shaders.end());
 
-    /*s->shaders.erase(shader);
+    s->shaders.erase(shader);
     s_createInfoCache->shaderCreateInfos.erase(shader);
-    s->shaderHandlePool.Destroy(shader);*/
+    s->shaderHandlePool.Destroy(shader);
 }
 
 GraphicsPipelineHandle Graphics::CreateGraphicsPipeline(const GraphicsPipelineCreateInfo& createInfo)
@@ -511,7 +539,7 @@ GraphicsPipelineHandle Graphics::CreateGraphicsPipeline(const GraphicsPipelineCr
     GraphicsPipelineHandle graphicsPipelineHandle = s->graphicsPipelineHandlePool.Create();
     s_createInfoCache->graphicsPipelineCreateInfos.insert(std::make_pair(graphicsPipelineHandle, createInfo));
 
-    BX_FAIL("TODO");
+    s->graphicsPipelines.insert(std::make_pair(graphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>{}));
 
     return graphicsPipelineHandle;
 }
@@ -520,9 +548,9 @@ void Graphics::DestroyGraphicsPipeline(GraphicsPipelineHandle& graphicsPipeline)
 {
     BX_ENSURE(graphicsPipeline);
 
-    /*s->graphicsPipelines.erase(graphicsPipeline);
+    s->graphicsPipelines.erase(graphicsPipeline);
     s_createInfoCache->graphicsPipelineCreateInfos.erase(graphicsPipeline);
-    s->graphicsPipelineHandlePool.Destroy(graphicsPipeline);*/
+    s->graphicsPipelineHandlePool.Destroy(graphicsPipeline);
 }
 
 ComputePipelineHandle Graphics::CreateComputePipeline(const ComputePipelineCreateInfo& createInfo)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -93,6 +93,7 @@ struct State : NoCopy
 
     HashMap<BufferHandle, std::shared_ptr<Buffer>> buffers;
     HashMap<TextureHandle, std::shared_ptr<Image>> textures;
+    HashMap<ShaderHandle, std::shared_ptr<Shader>> shaders;
 
     RenderPassHandle activeRenderPass = RenderPassHandle::null;
     ComputePassHandle activeComputePass = ComputePassHandle::null;
@@ -465,7 +466,10 @@ ShaderHandle Graphics::CreateShader(const ShaderCreateInfo& createInfo)
     }
     }
 
-    BX_FAIL("TODO");
+    VkShaderStageFlagBits stage = ShaderTypeToVk(createInfo.shaderType);
+
+    std::shared_ptr<Shader> shader(new Shader(createInfo.name, s->device, stage, meta + createInfo.src));
+    s->shaders.emplace(shaderHandle, shader);
 
     return shaderHandle;
 }

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -342,7 +342,11 @@ void Graphics::NewFrame()
 
 void Graphics::EndFrame()
 {
-    s->cmdQueue->SubmitCmdList(s->uploadCmdList, nullptr, {}, {}, {});
+    if (s->uploadCmdList)
+    {
+        s->cmdQueue->SubmitCmdList(s->uploadCmdList, nullptr, {}, {}, {});
+        s->uploadCmdList.reset();
+    }
 
     if (Window::IsActive())
     {
@@ -351,6 +355,11 @@ void Graphics::EndFrame()
 
         Rect2D swapchainExtent = s->swapchain->Extent();
         size_t currentFrame = static_cast<size_t>(s->swapchain->GetCurrentFrameIdx());
+
+        s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+        s->cmdList->TransitionImageLayout(s->depthImage, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
 
         // Swapchain present pass
         s->cmdList->BeginRenderPass(s->renderPass, s->framebuffer,
@@ -365,7 +374,6 @@ void Graphics::EndFrame()
             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
         s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-        //    VK_ACCESS_SHADER_READ_BIT,
             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
         s->cmdList->TransitionImageLayout(s->swapchain->GetImage(currentFrame),
             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
@@ -388,12 +396,11 @@ void Graphics::EndFrame()
 
         s->cmdList->TransitionImageLayout(
             s->colorImage, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-        //    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
         s->cmdList->TransitionImageLayout(s->swapchain->GetImage(currentFrame),
             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);// VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
         // Execute all rendering cmds when the image is available
         List<Semaphore*> waitSemaphores{ &s->swapchain->GetImageAvailableSemaphore() };
@@ -410,7 +417,6 @@ void Graphics::EndFrame()
     }
 
     s->cmdList.reset();
-    s->uploadCmdList.reset();
 }
 
 const BufferHandle& Graphics::EmptyBuffer()
@@ -803,11 +809,21 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
             height = createInfo.size.height;
         }
     }
-    framebufferInfo.renderPass = RenderPassCache::Get(renderPassInfo);
+
+    std::shared_ptr<RenderPass> loadRenderPass = RenderPassCache::Get(renderPassInfo);
+
+    RenderPassInfo noClearRenderPassInfo = renderPassInfo; // TODO: check if duplicate is required
+    noClearRenderPassInfo.clear = false;
+    std::shared_ptr<RenderPass> renderPass = RenderPassCache::Get(noClearRenderPassInfo);
+
+    framebufferInfo.renderPass = renderPass;
     
     std::shared_ptr<Framebuffer> framebuffer(new Framebuffer("framebuffer", s->device, framebufferInfo));
     s->cmdList->SetViewport(Rect2D(width, height));
     s->cmdList->SetScissor(Rect2D(width, height));
+
+    s->cmdList->BeginRenderPass(loadRenderPass, framebuffer, Color::Black());
+    s->cmdList->EndRenderPass();
 
     RenderPassHandle renderPassHandle = s->renderPassHandlePool.Create();
     s_createInfoCache->renderPassCreateInfos.insert(std::make_pair(renderPassHandle, descriptor));

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -39,7 +39,7 @@ constexpr bool ENABLE_VALIDATION =
 #ifdef _DEBUG
 true;
 #else
-true;
+false;
 #endif
 
 static String PRESENT_VERT_SRC = R"""(

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -726,6 +726,21 @@ void Graphics::EndComputePass(ComputePassHandle& computePass)
     s->boundComputePipeline = ComputePipelineHandle::null;
 }
 
+void WriteBuffer(const std::shared_ptr<Buffer>& buffer, const void* data, const BufferCreateInfo& createInfo, Optional<SizeType> size)
+{
+    BX_ASSERT(createInfo.usageFlags & BufferUsageFlags::COPY_DST, "Buffer must be created with BufferUsageFlags::COPY_DST when writing to.");
+
+    std::shared_ptr<Buffer> stagingBuffer(new Buffer(Log::Format("Write {} Staging Buffer", createInfo.name), s->device,
+        *s->physicalDevice, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+        static_cast<uint64_t>(createInfo.size), BufferLocation::CPU_TO_GPU));
+
+    void* bufferData = stagingBuffer->Map();
+    memcpy(bufferData, data, size.IsSome() ? size.Unwrap() : createInfo.size);
+    stagingBuffer->Unmap();
+
+    s->cmdList->CopyBuffers(stagingBuffer, buffer);
+}
+
 void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data)
 {
     BX_ENSURE(buffer && data);
@@ -733,8 +748,9 @@ void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data)
 
     auto bufferIter = s->buffers.find(buffer);
     BX_ENSURE(bufferIter != s->buffers.end());
+    auto& createInfo = GetBufferCreateInfo(buffer);
 
-    BX_FAIL("TODO");
+    ::WriteBuffer(bufferIter->second, data, createInfo, Optional<SizeType>::None());
 }
 
 void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data, SizeType size)
@@ -742,10 +758,11 @@ void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data, Si
     BX_ENSURE(buffer && data);
     BX_ASSERT(offset == 0, "Offset must be 0 for now.");
 
-    /*auto bufferIter = s->buffers.find(buffer);
-    BX_ENSURE(bufferIter != s->buffers.end());*/
+    auto bufferIter = s->buffers.find(buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());
+    auto& createInfo = GetBufferCreateInfo(buffer);
 
-    BX_FAIL("TODO");
+    ::WriteBuffer(bufferIter->second, data, createInfo, Optional<SizeType>::Some(size));
 }
 
 void Graphics::WriteTexture(TextureHandle texture, const void* data, const Extend3D& offset, const Extend3D& size)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -148,6 +148,7 @@ struct State : NoCopy
 
     std::shared_ptr<Fence> presentFence;
     std::shared_ptr<CmdList> cmdList;
+    std::shared_ptr<CmdList> uploadCmdList;
 };
 static std::unique_ptr<State> s;
 
@@ -341,6 +342,8 @@ void Graphics::NewFrame()
 
 void Graphics::EndFrame()
 {
+    s->cmdQueue->SubmitCmdList(s->uploadCmdList, nullptr, {}, {}, {});
+
     if (Window::IsActive())
     {
         // TODO: all rendering can happen before the image is available if we create a seperate present blit pipeline
@@ -407,6 +410,7 @@ void Graphics::EndFrame()
     }
 
     s->cmdList.reset();
+    s->uploadCmdList.reset();
 }
 
 const BufferHandle& Graphics::EmptyBuffer()
@@ -506,8 +510,12 @@ void Graphics::DestroySampler(SamplerHandle& sampler)
     BX_FAIL("TODO");
 }
 
-BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& createInfo)
+BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& _createInfo)
 {
+    // TODO: HACKS HACKS HACKS
+    BufferCreateInfo createInfo = _createInfo;
+    createInfo.usageFlags = createInfo.usageFlags | BufferUsageFlags::COPY_DST;
+
     BX_ENSURE(ValidateBufferCreateInfo(createInfo));
 
     BufferHandle bufferHandle = s->bufferHandlePool.Create();
@@ -523,7 +531,7 @@ BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& createInfo)
     if (createInfo.data)
     {
         // TODO!
-        // WriteBuffer(bufferHandle, 0, createInfo.data);
+        WriteBuffer(bufferHandle, 0, createInfo.data);
     }
 
     return bufferHandle;
@@ -1042,7 +1050,9 @@ void WriteBuffer(const std::shared_ptr<Buffer>& buffer, const void* data, const 
     memcpy(bufferData, data, size.IsSome() ? size.Unwrap() : createInfo.size);
     stagingBuffer->Unmap();
 
-    s->cmdList->CopyBuffers(stagingBuffer, buffer);
+    if (!s->uploadCmdList)
+        s->uploadCmdList = s->cmdQueue->GetCmdList();
+    s->uploadCmdList->CopyBuffers(stagingBuffer, buffer);
 }
 
 void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -437,7 +437,14 @@ ShaderHandle Graphics::CreateShader(const ShaderCreateInfo& createInfo)
     ShaderHandle shaderHandle = s->shaderHandlePool.Create();
     s_createInfoCache->shaderCreateInfos.insert(std::make_pair(shaderHandle, createInfo));
 
-    String meta = String("#version 450\n");
+    String meta = String(R""""(
+    #version 450
+    
+    #ifndef VULKAN
+    #define VULKAN
+    #endif // VULKAN
+    )"""");
+
     switch (createInfo.shaderType)
     {
     case ShaderType::VERTEX:

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -332,8 +332,12 @@ TextureViewHandle Graphics::GetSwapchainColorTargetView()
     return s->swapchainColorTargetViews[s->swapchain->GetCurrentFrameIdx()];
 }
 
-TextureHandle Graphics::CreateTexture(const TextureCreateInfo& createInfo)
+TextureHandle Graphics::CreateTexture(const TextureCreateInfo& _createInfo)
 {
+    // TODO: HACKS HACKS HACKS
+    TextureCreateInfo createInfo = _createInfo;
+    createInfo.usageFlags = createInfo.usageFlags | TextureUsageFlags::COPY_DST;
+
     BX_ENSURE(ValidateTextureCreateInfo(createInfo));
 
     TextureHandle textureHandle = s->textureHandlePool.Create();
@@ -354,7 +358,7 @@ TextureHandle Graphics::CreateTexture(const TextureCreateInfo& createInfo)
     if (createInfo.data)
     {
         // TODO!
-        // WriteTexture(textureHandle, 0, createInfo.data);
+        WriteTexture(textureHandle, createInfo.data, Extend3D(0, 0, 0), createInfo.size);
     }
 
     return textureHandle;
@@ -992,12 +996,26 @@ void Graphics::WriteTexture(TextureHandle texture, const void* data, const Exten
 {
     BX_ENSURE(texture && data);
 
-    /*auto textureIter = s->textures.find(texture);
-    BX_ENSURE(textureIter != s->textures.end());*/
-
+    auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());
     auto createInfo = GetTextureCreateInfo(texture);
 
-    BX_FAIL("TODO");
+    BX_ASSERT(createInfo.usageFlags & TextureUsageFlags::COPY_DST, "Texture must be created with TextureUsageFlags::COPY_DST when writing to.");
+
+    u32 sizeInBytes = SizeOfTexturePixels(createInfo);
+
+    std::shared_ptr<Buffer> stagingBuffer(new Buffer(Log::Format("Write {} Staging Buffer", createInfo.name), s->device,
+        *s->physicalDevice, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+        static_cast<uint64_t>(sizeInBytes), BufferLocation::CPU_TO_GPU));
+
+    void* bufferData = stagingBuffer->Map();
+    memcpy(bufferData, data, sizeInBytes);
+    stagingBuffer->Unmap();
+
+    if (!s->uploadCmdList)
+        s->uploadCmdList = s->cmdQueue->GetCmdList();
+    s->uploadCmdList->TransitionImageLayout(textureIter->second, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    s->uploadCmdList->CopyBuffers(stagingBuffer, textureIter->second);
 }
 
 void Graphics::ReadTexture(TextureHandle texture, void* data, const Extend3D& offset, const Extend3D& size)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -108,6 +108,7 @@ struct State : NoCopy
     HashMap<ShaderHandle, std::shared_ptr<Shader>> shaders;
     HashMap<GraphicsPipelineHandle, HashMap<RenderPassInfo, std::shared_ptr<GraphicsPipeline>>> graphicsPipelines;
     HashMap<GraphicsPipelineHandle, const List<std::shared_ptr<DescriptorSetLayout>>> graphicsPipelineLayouts;
+    HashMap<BindGroupHandle, std::shared_ptr<DescriptorSet>> bindGroups;
 
     std::shared_ptr<Framebuffer> renderPassFramebuffer = nullptr;
     std::shared_ptr<RenderPass> activeRenderPass = nullptr;
@@ -266,7 +267,6 @@ bool Graphics::Initialize()
         s->swapchainColorTargetViews[i] = TextureViewHandle{ textureHandle.id };
     }
     
-
     BuildRenderTargets();
     BuildDescriptors();
     BuildPipelines();
@@ -644,6 +644,51 @@ BindGroupHandle Graphics::CreateBindGroup(const BindGroupCreateInfo& createInfo)
     BindGroupHandle bindGroupHandle = s->bindGroupHandlePool.Create();
     s_createInfoCache->bindGroupCreateInfos.insert(std::make_pair(bindGroupHandle, createInfo));
 
+    u32 layoutIndex = GetBindGroupLayoutBindGroup(createInfo.layout);
+    u64 rawPipeline = GetBindGroupLayoutPipeline(createInfo.layout);
+    std::shared_ptr<DescriptorSetLayout> layout;
+    if (IsBindGroupLayoutGraphics(createInfo.layout))
+    {
+        auto layoutIter = s->graphicsPipelineLayouts.find(GraphicsPipelineHandle{ rawPipeline });
+        BX_ENSURE(layoutIter != s->graphicsPipelineLayouts.end());
+        layout = layoutIter->second[layoutIndex];
+    }
+    else
+    {
+        BX_FAIL("TODO");
+    }
+
+    std::shared_ptr<DescriptorSet> descriptorSet(new DescriptorSet(createInfo.name, s->device, s->descriptorPool, layout));
+
+    for (auto& entry : createInfo.entries)
+    {
+        switch (entry.resource.type)
+        {
+        case BindingResourceType::BUFFER:
+        {
+            auto bufferIter = s->buffers.find(entry.resource.buffer.buffer);
+            BX_ENSURE(bufferIter != s->buffers.end());
+
+            // TODO: read std::shared_ptr<DescriptorSetLayout> layout and cache some stuff to figure out what the buffer type is
+            descriptorSet->SetBuffer(entry.binding, VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, bufferIter->second);
+            break;
+        }
+        case BindingResourceType::TEXTURE_VIEW:
+        {
+            auto textureViewIter = s->textureViews.find(entry.resource.textureView);
+            BX_ENSURE(textureViewIter != s->textureViews.end());
+
+            // TODO: read std::shared_ptr<DescriptorSetLayout> layout and cache some stuff to figure out what the buffer type is
+            descriptorSet->SetImage(entry.binding, VkDescriptorType::VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, textureViewIter->second.texture, s->sampler);
+            break;
+        }
+        default:
+            BX_FAIL("TODO");
+        }
+    }
+
+    s->bindGroups.insert(std::make_pair(bindGroupHandle, descriptorSet));
+
     return bindGroupHandle;
 }
 
@@ -659,11 +704,14 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
 {
     BX_ASSERT(!s->activeRenderPassHandle, "Render pass already active.");
 
+    u32 width = 0;
+    u32 height = 0;
+
     RenderPassInfo renderPassInfo{};
     FramebufferInfo framebufferInfo{};
     for (auto& colorAttachment : descriptor.colorAttachments)
     {
-        auto& textureViewIter = s->textureViews.find(colorAttachment.view);
+        auto textureViewIter = s->textureViews.find(colorAttachment.view);
         BX_ENSURE(textureViewIter != s->textureViews.end());
         auto& textureCreateInfo = GetTextureCreateInfo(textureViewIter->second.handle);
 
@@ -671,12 +719,19 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
 
         VkFormat format = TextureFormatToVk(textureCreateInfo.format);
         renderPassInfo.colorFormats.push_back(format);
+
+        if (width == 0 && height == 0)
+        {
+            auto createInfo = GetTextureCreateInfo(textureViewIter->second.handle);
+            width = createInfo.size.width;
+            height = createInfo.size.height;
+        }
     }
     if (descriptor.depthStencilAttachment.IsSome())
     {
         auto& depthAttachment = descriptor.depthStencilAttachment.Unwrap();
 
-        auto& textureViewIter = s->textureViews.find(depthAttachment.view);
+        auto textureViewIter = s->textureViews.find(depthAttachment.view);
         BX_ENSURE(textureViewIter != s->textureViews.end());
         auto& textureCreateInfo = GetTextureCreateInfo(textureViewIter->second.handle);
 
@@ -684,11 +739,20 @@ RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descripto
 
         VkFormat format = TextureFormatToVk(textureCreateInfo.format);
         renderPassInfo.depthFormat = Optional<VkFormat>::Some(format);
+
+        if (width == 0 && height == 0)
+        {
+            auto createInfo = GetTextureCreateInfo(textureViewIter->second.handle);
+            width = createInfo.size.width;
+            height = createInfo.size.height;
+        }
     }
     framebufferInfo.renderPass = RenderPassCache::Get(renderPassInfo);
     
     std::shared_ptr<Framebuffer> framebuffer(new Framebuffer("framebuffer", s->device, framebufferInfo));
     s->cmdList->BeginRenderPass(framebufferInfo.renderPass, *framebuffer, Color::Magenta());
+    s->cmdList->SetViewport(Rect2D(width, height));
+    s->cmdList->SetScissor(Rect2D(width, height));
 
     RenderPassHandle renderPassHandle = s->renderPassHandlePool.Create();
     s_createInfoCache->renderPassCreateInfos.insert(std::make_pair(renderPassHandle, descriptor));
@@ -807,11 +871,11 @@ void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
     BX_ASSERT(s->activeRenderPassHandle || s->activeComputePass, "No render pass or compute pass active.");
     BX_ENSURE(bindGroup);
 
-    auto bindGroupCreateInfoIter = s_createInfoCache->bindGroupCreateInfos.find(bindGroup);
-    BX_ENSURE(bindGroupCreateInfoIter != s_createInfoCache->bindGroupCreateInfos.end());
-    BindGroupCreateInfo& createInfo = bindGroupCreateInfoIter->second;
+    auto bindGroupIter = s->bindGroups.find(bindGroup);
+    BX_ENSURE(bindGroupIter != s->bindGroups.end());
 
-    BX_FAIL("TODO");
+    // TODO: compute
+    s->cmdList->BindDescriptorSet(bindGroupIter->second, index, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
 void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -654,15 +654,13 @@ void Graphics::SetVertexBuffer(u32 slot, const BufferSlice& bufferSlice)
 {
     BX_ASSERT(s->activeRenderPass, "No render pass active.");
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
+    BX_ASSERT(slot == 0, "TODO");
     BX_ENSURE(bufferSlice.buffer);
 
-    /*auto bufferIter = s->buffers.find(bufferSlice.buffer);
-    BX_ENSURE(bufferIter != s->buffers.end());*/
+    auto bufferIter = s->buffers.find(bufferSlice.buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());
 
-    auto& pipelineCreateInfo = GetGraphicsPipelineCreateInfo(s->boundGraphicsPipeline);
-    u32 stride = pipelineCreateInfo.vertexBuffers[slot].stride;
-
-    BX_FAIL("TODO");
+    s->cmdList->BindVertexBuffer(bufferIter->second);
 }
 
 void Graphics::SetIndexBuffer(const BufferSlice& bufferSlice, IndexFormat format)
@@ -671,12 +669,12 @@ void Graphics::SetIndexBuffer(const BufferSlice& bufferSlice, IndexFormat format
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ENSURE(bufferSlice.buffer);
 
-    /*auto bufferIter = s->buffers.find(bufferSlice.buffer);
-    BX_ENSURE(bufferIter != s->buffers.end());*/
+    auto bufferIter = s->buffers.find(bufferSlice.buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());
 
     s->boundIndexFormat = Optional<IndexFormat>::Some(format);
 
-    BX_FAIL("TODO");
+    s->cmdList->BindIndexBuffer(bufferIter->second, format == IndexFormat::UINT16 ? VkIndexType::VK_INDEX_TYPE_UINT16 : VkIndexType::VK_INDEX_TYPE_UINT32);
 }
 
 void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
@@ -697,8 +695,7 @@ void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)
     BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
     BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
 
-    auto& info = GetGraphicsPipelineCreateInfo(s->boundGraphicsPipeline);
-    BX_FAIL("TODO");
+    s->cmdList->Draw(vertexCount, instanceCount, firstVertex);
 }
 
 void Graphics::DrawIndexed(u32 indexCount, u32 instanceCount)
@@ -708,8 +705,7 @@ void Graphics::DrawIndexed(u32 indexCount, u32 instanceCount)
     BX_ASSERT(s->boundIndexFormat.IsSome(), "No index buffer bound.");
     BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
 
-    auto& info = GetGraphicsPipelineCreateInfo(s->boundGraphicsPipeline);
-    BX_FAIL("TODO");
+    s->cmdList->DrawElements(indexCount, instanceCount);
 }
 
 void Graphics::EndRenderPass(RenderPassHandle& renderPass)

--- a/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
+++ b/src/bx/engine/modules/graphics/backend/graphics_vulkan.cpp
@@ -1,0 +1,774 @@
+#include "bx/engine/modules/graphics/backend/graphics_vulkan.hpp"
+
+#include "bx/engine/modules/graphics/type_validation.hpp"
+
+#include "bx/engine/core/file.hpp"
+#include "bx/engine/core/profiler.hpp"
+#include "bx/engine/core/memory.hpp"
+#include "bx/engine/core/macros.hpp"
+#include "bx/engine/containers/array.hpp"
+
+#include "bx/engine/modules/window.hpp"
+#include "bx/engine/modules/imgui.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/fence.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/semaphore.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/sampler.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/swapchain.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_pool.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/shader.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/rect2d.hpp"
+using namespace Vk;
+
+#ifdef BX_WINDOW_GLFW_BACKEND
+#include "bx/engine/modules/window/backend/window_glfw.hpp"
+#endif
+
+constexpr bool ENABLE_VALIDATION =
+#ifdef _DEBUG
+true;
+#else
+true;
+#endif
+
+static String PRESENT_VERT_SRC = R"""(
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) out vec2 fragTexCoord;
+
+void main() {
+    fragTexCoord = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(fragTexCoord * 2.0f + -1.0f, 0.0f, 1.0f);
+    fragTexCoord.y = -fragTexCoord.y;
+}
+)""";
+
+static String PRESENT_FRAG_SRC = R"""(
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) in vec2 fragTexCoord;
+
+layout(location = 0) out vec4 outColor;
+
+layout(binding = 0) uniform sampler2D colorImage;
+
+void main() {
+    vec3 color = texture(colorImage, fragTexCoord).rgb;
+    outColor = vec4(color, 1.0);
+}
+)""";
+
+struct State : NoCopy
+{
+    ~State()
+    {
+        device->WaitIdle();
+    }
+
+    HandlePool<BufferApi> bufferHandlePool;
+    HandlePool<TextureApi> textureHandlePool;
+    HandlePool<TextureViewApi> textureViewHandlePool;
+    HandlePool<SamplerApi> samplerHandlePool;
+    HandlePool<ShaderApi> shaderHandlePool;
+    HandlePool<GraphicsPipelineApi> graphicsPipelineHandlePool;
+    HandlePool<ComputePipelineApi> computePipelineHandlePool;
+    HandlePool<RenderPassApi> renderPassHandlePool;
+    HandlePool<ComputePassApi> computePassHandlePool;
+    HandlePool<BindGroupApi> bindGroupHandlePool;
+
+    RenderPassHandle activeRenderPass = RenderPassHandle::null;
+    ComputePassHandle activeComputePass = ComputePassHandle::null;
+    GraphicsPipelineHandle boundGraphicsPipeline = GraphicsPipelineHandle::null;
+    ComputePipelineHandle boundComputePipeline = ComputePipelineHandle::null;
+    Optional<IndexFormat> boundIndexFormat = Optional<IndexFormat>::None();
+
+    BufferHandle emptyBuffer = BufferHandle::null;
+    TextureHandle emptyTexture = TextureHandle::null;
+
+    TextureHandle swapchainColorTarget = TextureHandle::null;
+    TextureViewHandle swapchainColorTargetView = TextureViewHandle::null;
+
+    std::shared_ptr<Instance> instance;
+    std::unique_ptr<PhysicalDevice> physicalDevice;
+    std::shared_ptr<Device> device;
+    std::unique_ptr<CmdQueue> cmdQueue;
+    std::shared_ptr<DescriptorPool> descriptorPool;
+    std::unique_ptr<Swapchain> swapchain;
+
+    std::shared_ptr<Image> colorImage;
+    std::shared_ptr<Image> depthImage;
+    std::unique_ptr<Framebuffer> framebuffer;
+    std::shared_ptr<RenderPass> renderPass;
+    std::shared_ptr<Sampler> sampler;
+
+    std::shared_ptr<GraphicsPipeline> presentPipeline;
+    std::shared_ptr<DescriptorSetLayout> presentDescriptorSetLayout;
+    Array<std::shared_ptr<DescriptorSet>, Swapchain::MAX_FRAMES_IN_FLIGHT> presentDescriptorSets = { nullptr, nullptr };
+
+    std::shared_ptr<Fence> presentFence;
+    std::shared_ptr<CmdList> cmdList;
+};
+static std::unique_ptr<State> s;
+
+void BuildSwapchain()
+{
+    i32 width, height;
+    Window::GetSize(&width, &height);
+
+    s->swapchain.reset();
+    s->swapchain = std::make_unique<Swapchain>(static_cast<u32>(width), static_cast<u32>(height), *s->instance, s->device, *s->physicalDevice);
+}
+
+void BuildRenderTargets()
+{
+    i32 width, height;
+    Window::GetSize(&width, &height);
+
+    s->colorImage = std::make_shared<Image>(
+        "Color Image", s->device, *s->physicalDevice, width, height, 1,
+        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+        VK_IMAGE_USAGE_STORAGE_BIT,
+        VK_FORMAT_R16G16B16A16_SFLOAT);
+    s->depthImage = std::make_shared<Image>(
+        "Depth Image", s->device, *s->physicalDevice, width, height, 1,
+        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+        VK_FORMAT_D24_UNORM_S8_UINT);
+
+    s->renderPass = std::make_shared<RenderPass>("Main Render Pass",
+        s->device, List<VkFormat>{ s->colorImage->Format() },
+        Optional<VkFormat>::Some(s->depthImage->Format()));
+    List<std::shared_ptr<Image>> images{ s->colorImage, s->depthImage };
+    s->framebuffer = std::make_unique<Framebuffer>("Main Framebuffer", s->device, images, s->renderPass);
+}
+
+void BuildDescriptors()
+{
+    VkDescriptorSetLayoutBinding presentBinding0{};
+    presentBinding0.binding = 0;
+    presentBinding0.descriptorCount = 1;
+    presentBinding0.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    presentBinding0.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    s->presentDescriptorSetLayout = std::make_shared<DescriptorSetLayout>(
+        "Present Descriptor Set Layout 0",
+        s->device, List<VkDescriptorSetLayoutBinding>{ presentBinding0 });
+
+    for (size_t i = 0; i < s->presentDescriptorSets.size(); i++) {
+        s->presentDescriptorSets[i] = std::make_shared<DescriptorSet>(
+            "Present Descriptor Set 0",
+            s->device, s->descriptorPool, s->presentDescriptorSetLayout);
+    }
+}
+
+void BuildPipelines()
+{
+    std::shared_ptr<Shader> presentVertexShader =
+        std::make_shared<Shader>("present vert", s->device, VK_SHADER_STAGE_VERTEX_BIT, PRESENT_VERT_SRC);
+    std::shared_ptr<Shader> presentFragmentShader =
+        std::make_shared<Shader>("present frag", s->device, VK_SHADER_STAGE_FRAGMENT_BIT, PRESENT_FRAG_SRC);
+
+    GraphicsPipelineInfo presentInfo{};
+    presentInfo.ignoreDepth = true;
+    presentInfo.inputVertices = false;
+    std::vector<const Shader*> presentShaders = { presentVertexShader.get(),
+                                                 presentFragmentShader.get() };
+    s->presentPipeline = std::make_shared<GraphicsPipeline>(
+        s->device, presentShaders, s->swapchain->GetRenderPass(),
+        std::vector<std::shared_ptr<DescriptorSetLayout>>{s->presentDescriptorSetLayout},
+        std::vector<PushConstantRange>{}, presentInfo);
+}
+
+bool Graphics::Initialize()
+{
+    s_createInfoCache = std::unique_ptr<CreateInfoCache>(new CreateInfoCache());
+    s = std::make_unique<State>();
+
+#ifdef BX_WINDOW_GLFW_BACKEND
+    GLFWwindow* glfwWindow = WindowGLFW::GetWindowPtr();
+
+    uint32_t extensionsCount = 0;
+    const char** extensions = glfwGetRequiredInstanceExtensions(&extensionsCount);
+
+#else
+
+    BX_LOGE("Window backend not supported!");
+    return false;
+#endif
+
+    s->instance = std::make_shared<Instance>((void*)glfwWindow, ENABLE_VALIDATION);
+    s->physicalDevice = std::make_unique<PhysicalDevice>(*s->instance);
+    s->device = std::make_shared<Device>(s->instance, *s->physicalDevice, ENABLE_VALIDATION);
+    s->cmdQueue = std::make_unique<CmdQueue>(s->device, *s->physicalDevice, QueueType::GRAPHICS);
+    s->descriptorPool = std::make_shared<DescriptorPool>(s->device);
+    s->sampler = std::make_shared<Sampler>("Sampler", s->device, *s->physicalDevice,
+        SamplerInfo{});
+
+    BuildSwapchain();
+    BuildRenderTargets();
+    BuildDescriptors();
+    BuildPipelines();
+
+    return true;
+}
+
+void Graphics::Shutdown()
+{
+    s.reset();
+}
+
+void Graphics::Reload()
+{
+    // TODO: No implementation
+}
+
+void Graphics::NewFrame()
+{
+    s->cmdQueue->ProcessCmdLists();
+
+    if (Window::IsActive())
+    {
+        if (Window::WasResized())
+        {
+            BuildSwapchain();
+            BuildRenderTargets();
+            BuildPipelines();
+        }
+
+        s->presentFence = s->swapchain->NextImage();
+
+        // All cmds of the entire frame will be recorded into a single cmd list
+        // This is because we designed the graphics module api to act like it's immediate
+        s->cmdList = s->cmdQueue->GetCmdList();
+    }
+}
+
+void Graphics::EndFrame()
+{
+    if (Window::IsActive())
+    {
+        // TODO: all rendering can happen before the image is available if we create a seperate present blit pipeline
+        // This can also act as a hdr to sdr conversion and enable us to render in hdr
+
+        Rect2D swapchainExtent = s->swapchain->Extent();
+        size_t currentFrame = static_cast<size_t>(s->swapchain->GetCurrentFrameIdx());
+
+        // Swapchain present pass
+        s->cmdList->BeginRenderPass(s->renderPass, *s->framebuffer,
+            Color(0.6f, 0.8f, 1.0f, 1.0f));
+        Rect2D imgExtent(static_cast<float>(s->colorImage->Width()),
+            static_cast<float>(s->colorImage->Height()));
+        s->cmdList->SetScissor(imgExtent);
+        s->cmdList->SetViewport(imgExtent);
+        // TODO: render da shit
+        s->cmdList->EndRenderPass();
+
+        s->cmdList->TransitionImageLayout(s->colorImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            VK_ACCESS_SHADER_READ_BIT,
+            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        s->cmdList->BeginRenderPass(s->swapchain->GetRenderPass(),
+            s->swapchain->GetCurrentFramebuffer(),
+            Color(0.1f, 0.1f, 0.1f, 1.0f));
+        s->cmdList->SetScissor(swapchainExtent);
+        s->cmdList->SetViewport(swapchainExtent);
+        s->cmdList->BindGraphicsPipeline(s->presentPipeline);
+        s->presentDescriptorSets[currentFrame]->SetImage(
+            0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, s->colorImage, s->sampler);
+        s->cmdList->BindDescriptorSet(s->presentDescriptorSets[currentFrame], 0);
+        s->cmdList->Draw(3);
+        ImGuiImpl::EndFrame();
+        s->cmdList->EndRenderPass();
+        s->cmdList->TransitionImageLayout(
+            s->colorImage, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+
+        // Execute all rendering cmds when the image is available
+        List<Semaphore*> waitSemaphores{ &s->swapchain->GetImageAvailableSemaphore() };
+        List<VkPipelineStageFlags> presentWaitStages{ VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
+        List<Semaphore*> presentSignalSemaphores{
+            &s->swapchain->GetRenderFinishedSemaphore() };
+        s->cmdQueue->SubmitCmdList(s->cmdList, s->presentFence, waitSemaphores, presentWaitStages,
+            presentSignalSemaphores);
+
+        // Present when rendering is finished, indicated by the `presentSignalSemaphores`
+        s->swapchain->Present(*s->cmdQueue, *s->presentFence, presentSignalSemaphores);
+    }
+
+    s->cmdList.reset();
+}
+
+const BufferHandle& Graphics::EmptyBuffer()
+{
+    return s->emptyBuffer;
+}
+
+const TextureHandle& Graphics::EmptyTexture()
+{
+    return s->emptyTexture;
+}
+
+TextureHandle Graphics::GetSwapchainColorTarget()
+{
+    return s->swapchainColorTarget;
+}
+
+TextureViewHandle Graphics::GetSwapchainColorTargetView()
+{
+    return s->swapchainColorTargetView;
+}
+
+TextureHandle Graphics::CreateTexture(const TextureCreateInfo& createInfo)
+{
+    BX_ENSURE(ValidateTextureCreateInfo(createInfo));
+
+    TextureHandle textureHandle = s->textureHandlePool.Create();
+    s_createInfoCache->textureCreateInfos.insert(std::make_pair(textureHandle, createInfo.WithoutData()));
+
+    BX_FAIL("TODO");
+
+    return textureHandle;
+}
+
+void Graphics::DestroyTexture(TextureHandle& texture)
+{
+    BX_ENSURE(texture);
+
+   /* auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());*/
+    BX_FAIL("TODO");
+
+    /*s->textures.erase(texture);
+    s_createInfoCache->textureCreateInfos.erase(texture);
+    s->textureHandlePool.Destroy(texture);*/
+}
+
+TextureViewHandle Graphics::CreateTextureView(TextureHandle texture)
+{
+    BX_ENSURE(texture);
+
+    TextureViewHandle textureViewHandle = s->textureViewHandlePool.Create();
+
+    /*auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());*/
+
+    BX_FAIL("TODO");
+
+    return textureViewHandle;
+}
+
+void Graphics::DestroyTextureView(TextureViewHandle& textureView)
+{
+    BX_ENSURE(textureView);
+
+    /*s->textureViews.erase(textureView);
+    s->textureViewHandlePool.Destroy(textureView);*/
+}
+
+SamplerHandle Graphics::CreateSampler(const SamplerCreateInfo& create)
+{
+    BX_FAIL("TODO");
+    return SamplerHandle::null;
+}
+
+void Graphics::DestroySampler(SamplerHandle& sampler)
+{
+    BX_FAIL("TODO");
+}
+
+BufferHandle Graphics::CreateBuffer(const BufferCreateInfo& createInfo)
+{
+    BX_ENSURE(ValidateBufferCreateInfo(createInfo));
+
+    BufferHandle bufferHandle = s->bufferHandlePool.Create();
+    s_createInfoCache->bufferCreateInfos.insert(std::make_pair(bufferHandle, createInfo.WithoutData()));
+
+    BX_FAIL("TODO");
+
+    return bufferHandle;
+}
+
+void Graphics::DestroyBuffer(BufferHandle& buffer)
+{
+    BX_ENSURE(buffer);
+
+    /*auto bufferIter = s->buffers.find(buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());*/
+    BX_FAIL("TODO");
+
+    /*s->buffers.erase(buffer);
+    s_createInfoCache->bufferCreateInfos.erase(buffer);
+    s->bufferHandlePool.Destroy(buffer);*/
+}
+
+ShaderHandle Graphics::CreateShader(const ShaderCreateInfo& createInfo)
+{
+    BX_ENSURE(ValidateShaderCreateInfo(createInfo));
+
+    ShaderHandle shaderHandle = s->shaderHandlePool.Create();
+    s_createInfoCache->shaderCreateInfos.insert(std::make_pair(shaderHandle, createInfo));
+
+    String meta = String("#version 450\n");
+    switch (createInfo.shaderType)
+    {
+    case ShaderType::VERTEX:
+    {
+        meta += String("#define VERTEX\n");
+        break;
+    }
+    case ShaderType::FRAGMENT:
+    {
+        meta += String("#define FRAGMENT\n");
+        break;
+    }
+    }
+
+    BX_FAIL("TODO");
+
+    return shaderHandle;
+}
+
+void Graphics::DestroyShader(ShaderHandle& shader)
+{
+    BX_ENSURE(shader);
+
+    /*auto shaderIter = s->shaders.find(shader);
+    BX_ENSURE(shaderIter != s->shaders.end());*/
+
+    /*s->shaders.erase(shader);
+    s_createInfoCache->shaderCreateInfos.erase(shader);
+    s->shaderHandlePool.Destroy(shader);*/
+}
+
+GraphicsPipelineHandle Graphics::CreateGraphicsPipeline(const GraphicsPipelineCreateInfo& createInfo)
+{
+    BX_ENSURE(ValidateGraphicsPipelineCreateInfo(createInfo));
+
+    GraphicsPipelineHandle graphicsPipelineHandle = s->graphicsPipelineHandlePool.Create();
+    s_createInfoCache->graphicsPipelineCreateInfos.insert(std::make_pair(graphicsPipelineHandle, createInfo));
+
+    BX_FAIL("TODO");
+
+    return graphicsPipelineHandle;
+}
+
+void Graphics::DestroyGraphicsPipeline(GraphicsPipelineHandle& graphicsPipeline)
+{
+    BX_ENSURE(graphicsPipeline);
+
+    /*s->graphicsPipelines.erase(graphicsPipeline);
+    s_createInfoCache->graphicsPipelineCreateInfos.erase(graphicsPipeline);
+    s->graphicsPipelineHandlePool.Destroy(graphicsPipeline);*/
+}
+
+ComputePipelineHandle Graphics::CreateComputePipeline(const ComputePipelineCreateInfo& createInfo)
+{
+    BX_ENSURE(ValidateComputePipelineCreateInfo(createInfo));
+
+    ComputePipelineHandle computePipelineHandle = s->computePipelineHandlePool.Create();
+    s_createInfoCache->computePipelineCreateInfos.insert(std::make_pair(computePipelineHandle, createInfo));
+
+    /*auto shaderIter = s->shaders.find(createInfo.shader);
+    BX_ENSURE(shaderIter != s->shaders.end());*/
+
+    BX_FAIL("TODO");
+
+    return computePipelineHandle;
+}
+
+void Graphics::DestroyComputePipeline(ComputePipelineHandle& computePipeline)
+{
+    BX_ENSURE(computePipeline);
+
+   /* s->computePipelines.erase(computePipeline);
+    s_createInfoCache->computePipelineCreateInfos.erase(computePipeline);
+    s->computePipelineHandlePool.Destroy(computePipeline);*/
+}
+
+BindGroupLayoutHandle Graphics::GetBindGroupLayout(GraphicsPipelineHandle graphicsPipeline, u32 bindGroup)
+{
+    u64 id = graphicsPipeline.id << 10 | static_cast<u64>(static_cast<u8>(bindGroup)) << 1 | 1;
+    return BindGroupLayoutHandle{ id };
+}
+
+BindGroupLayoutHandle Graphics::GetBindGroupLayout(ComputePipelineHandle computePipeline, u32 bindGroup)
+{
+    u64 id = computePipeline.id << 10 | static_cast<u64>(static_cast<u8>(bindGroup)) << 1 | 0;
+    return BindGroupLayoutHandle{ id };
+}
+
+u32 Graphics::GetBindGroupLayoutBindGroup(BindGroupLayoutHandle bindGroupLayout)
+{
+    return static_cast<u32>((bindGroupLayout.id << 54) >> 55);
+}
+
+b8 Graphics::IsBindGroupLayoutGraphics(BindGroupLayoutHandle bindGroupLayout)
+{
+    return static_cast<b8>(bindGroupLayout.id << 63);
+}
+
+u64 Graphics::GetBindGroupLayoutPipeline(BindGroupLayoutHandle bindGroupLayout)
+{
+    return bindGroupLayout.id >> 10;
+}
+
+BindGroupHandle Graphics::CreateBindGroup(const BindGroupCreateInfo& createInfo)
+{
+    BX_ENSURE(ValidateBindGroupCreateInfo(createInfo));
+
+    BindGroupHandle bindGroupHandle = s->bindGroupHandlePool.Create();
+    s_createInfoCache->bindGroupCreateInfos.insert(std::make_pair(bindGroupHandle, createInfo));
+
+    return bindGroupHandle;
+}
+
+void Graphics::DestroyBindGroup(BindGroupHandle& bindGroup)
+{
+    BX_ENSURE(bindGroup);
+
+    s_createInfoCache->bindGroupCreateInfos.erase(bindGroup);
+    s->bindGroupHandlePool.Destroy(bindGroup);
+}
+
+RenderPassHandle Graphics::BeginRenderPass(const RenderPassDescriptor& descriptor)
+{
+    BX_ASSERT(!s->activeRenderPass, "Render pass already active.");
+
+    BX_FAIL("TODO");
+
+    RenderPassHandle renderPassHandle = s->renderPassHandlePool.Create();
+    s_createInfoCache->renderPassCreateInfos.insert(std::make_pair(renderPassHandle, descriptor));
+
+    s->activeRenderPass = renderPassHandle;
+
+    return renderPassHandle;
+}
+
+void Graphics::SetGraphicsPipeline(GraphicsPipelineHandle graphicsPipeline)
+{
+    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ENSURE(graphicsPipeline);
+
+    s->boundGraphicsPipeline = graphicsPipeline;
+
+    /*auto pipelineIter = s->graphicsPipelines.find(graphicsPipeline);
+    BX_ENSURE(pipelineIter != s->graphicsPipelines.end());
+    auto& pipeline = pipelineIter->second;*/
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::SetVertexBuffer(u32 slot, const BufferSlice& bufferSlice)
+{
+    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
+    BX_ENSURE(bufferSlice.buffer);
+
+    /*auto bufferIter = s->buffers.find(bufferSlice.buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());*/
+
+    auto& pipelineCreateInfo = GetGraphicsPipelineCreateInfo(s->boundGraphicsPipeline);
+    u32 stride = pipelineCreateInfo.vertexBuffers[slot].stride;
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::SetIndexBuffer(const BufferSlice& bufferSlice, IndexFormat format)
+{
+    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
+    BX_ENSURE(bufferSlice.buffer);
+
+    /*auto bufferIter = s->buffers.find(bufferSlice.buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());*/
+
+    s->boundIndexFormat = Optional<IndexFormat>::Some(format);
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::SetBindGroup(u32 index, BindGroupHandle bindGroup)
+{
+    BX_ASSERT(s->activeRenderPass || s->activeComputePass, "No render pass or compute pass active.");
+    BX_ENSURE(bindGroup);
+
+    auto bindGroupCreateInfoIter = s_createInfoCache->bindGroupCreateInfos.find(bindGroup);
+    BX_ENSURE(bindGroupCreateInfoIter != s_createInfoCache->bindGroupCreateInfos.end());
+    BindGroupCreateInfo& createInfo = bindGroupCreateInfoIter->second;
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::Draw(u32 vertexCount, u32 firstVertex, u32 instanceCount)
+{
+    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
+    BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
+
+    auto& info = GetGraphicsPipelineCreateInfo(s->boundGraphicsPipeline);
+    BX_FAIL("TODO");
+}
+
+void Graphics::DrawIndexed(u32 indexCount, u32 instanceCount)
+{
+    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ASSERT(s->boundGraphicsPipeline, "No graphics pipeline bound.");
+    BX_ASSERT(s->boundIndexFormat.IsSome(), "No index buffer bound.");
+    BX_ASSERT(instanceCount > 0, "Instance count must be larger than 0.");
+
+    auto& info = GetGraphicsPipelineCreateInfo(s->boundGraphicsPipeline);
+    BX_FAIL("TODO");
+}
+
+void Graphics::EndRenderPass(RenderPassHandle& renderPass)
+{
+    BX_ASSERT(s->activeRenderPass, "No render pass active.");
+    BX_ENSURE(renderPass);
+
+    const RenderPassDescriptor& descriptor = Graphics::GetRenderPassDescriptor(renderPass);
+    BX_FAIL("TODO");
+
+    s->activeRenderPass = RenderPassHandle::null;
+    s->renderPassHandlePool.Destroy(renderPass);
+    s_createInfoCache->renderPassCreateInfos.erase(renderPass);
+
+    s->boundGraphicsPipeline = GraphicsPipelineHandle::null;
+}
+
+ComputePassHandle Graphics::BeginComputePass(const ComputePassDescriptor& descriptor)
+{
+    BX_ASSERT(!s->activeComputePass, "Compute pass already active.");
+
+    ComputePassHandle computePassHandle = s->computePassHandlePool.Create();
+    //s_createInfoCache->renderPass.insert(std::make_pair(renderPass, descriptor));
+
+    s->activeComputePass = computePassHandle;
+
+    return computePassHandle;
+}
+
+void Graphics::SetComputePipeline(ComputePipelineHandle computePipeline)
+{
+    BX_ASSERT(s->activeComputePass, "No compute pass active.");
+    BX_ENSURE(computePipeline);
+
+    s->boundComputePipeline = computePipeline;
+
+    /*auto pipelineIter = s->computePipelines.find(computePipeline);
+    BX_ENSURE(pipelineIter != s->computePipelines.end());
+    auto& pipeline = pipelineIter->second;*/
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::DispatchWorkgroups(u32 x, u32 y, u32 z)
+{
+    BX_ASSERT(s->activeComputePass, "No compute pass active.");
+    BX_ASSERT(s->boundComputePipeline, "No compute pipeline bound.");
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::EndComputePass(ComputePassHandle& computePass)
+{
+    BX_ASSERT(s->activeComputePass, "No compute pass active.");
+    BX_ENSURE(computePass);
+
+    s->activeComputePass = ComputePassHandle::null;
+    s->computePassHandlePool.Destroy(computePass);
+
+    s->boundComputePipeline = ComputePipelineHandle::null;
+}
+
+void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data)
+{
+    BX_ENSURE(buffer && data);
+    BX_ASSERT(offset == 0, "Offset must be 0 for now.");
+
+    /*auto bufferIter = s->buffers.find(buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());*/
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::WriteBuffer(BufferHandle buffer, u64 offset, const void* data, SizeType size)
+{
+    BX_ENSURE(buffer && data);
+    BX_ASSERT(offset == 0, "Offset must be 0 for now.");
+
+    /*auto bufferIter = s->buffers.find(buffer);
+    BX_ENSURE(bufferIter != s->buffers.end());*/
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::WriteTexture(TextureHandle texture, const void* data, const Extend3D& offset, const Extend3D& size)
+{
+    BX_ENSURE(texture && data);
+
+    /*auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());*/
+
+    auto createInfo = GetTextureCreateInfo(texture);
+
+    BX_FAIL("TODO");
+}
+
+void Graphics::ReadTexture(TextureHandle texture, void* data, const Extend3D& offset, const Extend3D& size)
+{
+    BX_ENSURE(texture);
+
+    /*auto textureIter = s->textures.find(texture);
+    BX_ENSURE(textureIter != s->textures.end());
+
+    auto createInfo = GetTextureCreateInfo(texture);*/
+
+    BX_FAIL("TODO");
+}
+
+// TODO: obliterate this obomination
+void Graphics::DebugDraw(const Mat4& viewProj, const DebugDrawAttribs& attribs, const List<DebugVertex>& vertices)
+{
+}
+
+// TODO: this can go when there's a imgui render impl using the higher level graphics module api
+
+#include <backends/imgui_impl_vulkan.h>
+ImGui_ImplVulkan_InitInfo GraphicsVulkan::ImGuiInitInfo()
+{
+    ImGui_ImplVulkan_InitInfo info{};
+    info.Instance = s->instance->GetInstance();
+    info.PhysicalDevice = s->physicalDevice->GetPhysicalDevice();
+    info.Device = s->device->GetDevice();
+    info.QueueFamily = s->physicalDevice->GraphicsFamily();
+    info.Queue = s->cmdQueue->GetQueue();
+    info.DescriptorPool = s->descriptorPool->GetPool();
+    info.RenderPass = s->swapchain->GetRenderPass()->GetRenderPass(); // TODO: this breaks on resize
+    info.MinImageCount = 2; // TODO: should this be properly queried from the swapchain?
+    info.ImageCount = 2;
+    info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+    info.MinAllocationSize = 1024 * 1024;
+    return info;
+}
+
+VkCommandBuffer GraphicsVulkan::RawCommandBuffer()
+{
+    return s->cmdList->GetCommandBuffer();
+}
+
+void GraphicsVulkan::WaitIdle()
+{
+    s->device->WaitIdle();
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp
@@ -1,0 +1,91 @@
+#include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    Buffer::Buffer(const std::string& name, std::shared_ptr<Device> device,
+        const PhysicalDevice& physicalDevice, VkBufferUsageFlags usage, uint64_t size,
+        BufferLocation location)
+        : size(size), device(device) {
+        VkBufferCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        createInfo.size = size;
+        createInfo.sharingMode = VkSharingMode::VK_SHARING_MODE_EXCLUSIVE;
+        createInfo.usage = usage;
+
+        VmaAllocationCreateInfo allocCreateInfo{};
+        if (physicalDevice.RayTracingSuitable()) {
+            allocCreateInfo.flags = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+            createInfo.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+        }
+        if (location == BufferLocation::CPU_TO_GPU) {
+            allocCreateInfo.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+        }
+        allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+        BX_ASSERT(!vmaCreateBuffer(device->GetAllocator(), &createInfo, &allocCreateInfo,
+            &this->buffer, &this->allocation, nullptr),
+            "Failed to create buffer.");
+        DebugNames::Set(*device, VK_OBJECT_TYPE_BUFFER, reinterpret_cast<uint64_t>(this->buffer),
+            name);
+    }
+
+    Buffer::Buffer(Buffer&& other) noexcept
+        : size(other.size),
+        buffer(other.buffer),
+        allocation(other.allocation),
+        device(other.device) {
+        other.buffer = VK_NULL_HANDLE;
+        other.allocation = VK_NULL_HANDLE;
+    }
+
+    Buffer& Buffer::operator=(Buffer&& other) noexcept {
+        this->size = other.size;
+        this->buffer = other.buffer;
+        this->allocation = other.allocation;
+        other.buffer = VK_NULL_HANDLE;
+        other.allocation = VK_NULL_HANDLE;
+        return *this;
+    }
+
+    Buffer::~Buffer() {
+        if (this->buffer) {
+            vmaDestroyBuffer(this->device->GetAllocator(), this->buffer, this->allocation);
+        }
+    }
+
+    void* Buffer::Map() {
+        void* data;
+        vmaMapMemory(this->device->GetAllocator(), this->allocation, &data);
+        return data;
+    }
+
+    void Buffer::Unmap() {
+        vmaUnmapMemory(this->device->GetAllocator(), this->allocation);
+        vmaFlushAllocation(this->device->GetAllocator(), this->allocation, 0, this->size);
+    }
+
+    uint64_t Buffer::Size() const {
+        return this->size;
+    }
+
+    VkBuffer Buffer::GetBuffer() const {
+        return this->buffer;
+    }
+
+    VkDeviceAddress Buffer::GetDeviceAddress() const {
+        VkBufferDeviceAddressInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+        info.buffer = this->buffer;
+        info.pNext = nullptr;
+
+        VkDevice device = this->device->GetDevice();
+        const VkBufferDeviceAddressInfo* pInfo = &info;
+        return vkGetBufferDeviceAddress(device, pInfo);
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp
@@ -25,6 +25,7 @@ namespace Vk
         }
         if (location == BufferLocation::CPU_TO_GPU) {
             allocCreateInfo.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+            allocCreateInfo.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;//??
         }
         allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/buffer.cpp
@@ -28,7 +28,7 @@ namespace Vk
         }
         allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
 
-        BX_ASSERT(!vmaCreateBuffer(device->GetAllocator(), &createInfo, &allocCreateInfo,
+        VK_ASSERT(!vmaCreateBuffer(device->GetAllocator(), &createInfo, &allocCreateInfo,
             &this->buffer, &this->allocation, nullptr),
             "Failed to create buffer.");
         DebugNames::Set(*device, VK_OBJECT_TYPE_BUFFER, reinterpret_cast<uint64_t>(this->buffer),

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -299,9 +299,8 @@ namespace Vk
         this->trackedBuffers.push_back(vertexBuffer);
     }
 
-    void CmdList::BindIndexBuffer(std::shared_ptr<Buffer> indexBuffer) {
-        vkCmdBindIndexBuffer(this->cmdBuffer, indexBuffer->GetBuffer(), 0,
-            VkIndexType::VK_INDEX_TYPE_UINT32);
+    void CmdList::BindIndexBuffer(std::shared_ptr<Buffer> indexBuffer, VkIndexType type) {
+        vkCmdBindIndexBuffer(this->cmdBuffer, indexBuffer->GetBuffer(), 0, type);
 
         this->trackedBuffers.push_back(indexBuffer);
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -95,10 +95,10 @@ namespace Vk
 
     void CmdList::CopyImages(std::shared_ptr<Image> src, std::shared_ptr<Image> dst) {
         this->TransitionImageLayout(src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            VK_ACCESS_TRANSFER_READ_BIT,
+        //    VK_ACCESS_TRANSFER_READ_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT);
         this->TransitionImageLayout(dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-            VK_ACCESS_TRANSFER_WRITE_BIT,
+        //    VK_ACCESS_TRANSFER_WRITE_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT);
 
         VkImageBlit blit{};
@@ -130,7 +130,7 @@ namespace Vk
     void CmdList::CopyImagesIntoCubemap(const std::array<std::shared_ptr<Image>, 6>& images,
         std::shared_ptr<Image> cubemap) {
         this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-            VK_ACCESS_TRANSFER_WRITE_BIT,
+        //    VK_ACCESS_TRANSFER_WRITE_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT);
 
         VkImageCopy imageCopy{};
@@ -147,7 +147,7 @@ namespace Vk
 
         for (size_t i = 0; i < images.size(); i++) {
             this->TransitionImageLayout(images[i], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                VK_ACCESS_TRANSFER_READ_BIT,
+            //    VK_ACCESS_TRANSFER_READ_BIT,
                 VK_PIPELINE_STAGE_TRANSFER_BIT);
         }
 
@@ -172,7 +172,7 @@ namespace Vk
         }
 
         this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-            VK_ACCESS_SHADER_READ_BIT,
+        //    VK_ACCESS_SHADER_READ_BIT,
             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
     }
 
@@ -252,14 +252,8 @@ namespace Vk
         this->trackedImages.push_back(image);
     }
 
-    void CmdList::TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout,
-        VkAccessFlags access, VkPipelineStageFlags pipelineStage) {
-        ImageState imageState;
-        imageState.layout = layout;
-        imageState.accessFlags = access;
-        imageState.stageFlags = pipelineStage;
-
-        ResourceStateTracker::TransitionImage(this->cmdBuffer, *image, imageState);
+    void CmdList::TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout, VkPipelineStageFlags pipelineStage) {
+        ResourceStateTracker::TransitionImage(this->cmdBuffer, *image, layout, pipelineStage);
         this->trackedImages.push_back(image);
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -7,6 +7,7 @@
 #include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/compute_pipeline.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/rect2d.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp"
@@ -54,7 +55,7 @@ namespace Vk
         vkResetCommandBuffer(this->cmdBuffer, 0);
 
         this->boundGraphicsPipeline.reset();
-        //this->boundComputePipeline.reset();
+        this->boundComputePipeline.reset();
         this->trackedRenderPasses.clear();
         this->trackedBuffers.clear();
         this->trackedImages.clear();
@@ -363,10 +364,9 @@ namespace Vk
         VkPipelineBindPoint pipelineType) {
         VkDescriptorSet descriptorSets[] = { descriptorSet->GetDescriptorSet() };
 
-        VkPipelineLayout layout = this->boundGraphicsPipeline->GetLayout();
-        /*VkPipelineLayout layout = (pipelineType == VK_PIPELINE_BIND_POINT_GRAPHICS)
+        VkPipelineLayout layout = (pipelineType == VK_PIPELINE_BIND_POINT_GRAPHICS)
             ? this->boundGraphicsPipeline->GetLayout()
-            : this->boundComputePipeline->GetLayout();*/
+            : this->boundComputePipeline->GetLayout();
         vkCmdBindDescriptorSets(this->cmdBuffer, pipelineType, layout, set, 1, descriptorSets, 0,
             nullptr);
 
@@ -380,12 +380,12 @@ namespace Vk
         this->boundGraphicsPipeline = graphicsPipeline;
     }
 
-    /*void CmdList::BindComputePipeline(std::shared_ptr<ComputePipeline> computePipeline) {
+    void CmdList::BindComputePipeline(std::shared_ptr<ComputePipeline> computePipeline) {
         vkCmdBindPipeline(this->cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
             computePipeline->GetPipeline());
 
         this->boundComputePipeline = computePipeline;
-    }*/
+    }
 
     void CmdList::Draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
         uint32_t firstInstance) {
@@ -400,11 +400,6 @@ namespace Vk
 
     void CmdList::Dispatch(uint32_t x, uint32_t y, uint32_t z) {
         vkCmdDispatch(this->cmdBuffer, x, y, z);
-    }
-
-    void CmdList::TrackDescriptorSet(std::shared_ptr<DescriptorSet> descriptorSet)
-    {
-        this->trackedDescriptorSets.push_back(descriptorSet);
     }
 
     void CmdList::PushConstant(const std::string& name, void* constant, size_t size,

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -1,0 +1,408 @@
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/rect2d.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    CmdList::CmdList(std::shared_ptr<Device> device, const CmdQueue& cmdQueue)
+        : device(device), cmdQueue(cmdQueue) {
+        VkCommandBufferAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        allocInfo.commandPool = cmdQueue.GetCmdPool();
+        allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        allocInfo.commandBufferCount = 1;
+
+        BX_ASSERT(!vkAllocateCommandBuffers(device->GetDevice(), &allocInfo, &this->cmdBuffer),
+            "Failed to allocate command buffer.");
+    }
+
+    CmdList::~CmdList() {
+        vkFreeCommandBuffers(this->device->GetDevice(), this->cmdQueue.GetCmdPool(), 1,
+            &this->cmdBuffer);
+    }
+
+    VkCommandBuffer CmdList::GetCommandBuffer() const
+    {
+        return this->cmdBuffer;
+    }
+
+    void CmdList::Begin() {
+        VkCommandBufferBeginInfo beginInfo{};
+        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+
+        BX_ASSERT(!vkBeginCommandBuffer(this->cmdBuffer, &beginInfo),
+            "Failed to begin command buffer.");
+    }
+
+    void CmdList::End() {
+        BX_ASSERT(!vkEndCommandBuffer(this->cmdBuffer), "Failed to end command buffer.");
+    }
+
+    void CmdList::Reset() {
+        vkResetCommandBuffer(this->cmdBuffer, 0);
+
+        this->boundGraphicsPipeline.reset();
+        //this->boundComputePipeline.reset();
+        this->trackedRenderPasses.clear();
+        this->trackedBuffers.clear();
+        this->trackedImages.clear();
+        this->trackedDescriptorSets.clear();
+    }
+
+    void CmdList::CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Buffer> dst) {
+        BX_ASSERT(src->Size() == dst->Size(), "Copy buffers src and dst must have the same size.");
+
+        VkBufferCopy copyRegion{};
+        copyRegion.size = src->Size();
+
+        vkCmdCopyBuffer(this->cmdBuffer, src->GetBuffer(), dst->GetBuffer(), 1, &copyRegion);
+
+        this->trackedBuffers.push_back(src);
+        this->trackedBuffers.push_back(dst);
+    }
+
+    void CmdList::CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Image> dst) {
+        VkBufferImageCopy copyRegion{};
+        copyRegion.bufferOffset = 0;
+        copyRegion.bufferRowLength = 0;
+        copyRegion.bufferImageHeight = 0;
+        copyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        copyRegion.imageSubresource.mipLevel = 0;
+        copyRegion.imageSubresource.baseArrayLayer = 0;
+        copyRegion.imageSubresource.layerCount = 1;
+        copyRegion.imageOffset = { 0, 0, 0 };
+        copyRegion.imageExtent = { dst->Width(), dst->Height(), dst->Depth() };
+
+        vkCmdCopyBufferToImage(this->cmdBuffer, src->GetBuffer(), dst->GetImage(),
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyRegion);
+
+        this->trackedBuffers.push_back(src);
+        this->trackedImages.push_back(dst);
+    }
+
+    void CmdList::CopyImages(std::shared_ptr<Image> src, std::shared_ptr<Image> dst) {
+        this->TransitionImageLayout(src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            VK_ACCESS_TRANSFER_READ_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        this->TransitionImageLayout(dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_ACCESS_TRANSFER_WRITE_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+        VkImageBlit blit{};
+        blit.srcOffsets[0] = { 0, 0, 0 };
+        blit.srcOffsets[1] = { static_cast<int32_t>(src->Width()),
+                              static_cast<int32_t>(src->Height()),
+                              static_cast<int32_t>(src->Depth()) };
+        blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        blit.srcSubresource.mipLevel = 0;
+        blit.srcSubresource.baseArrayLayer = 0;
+        blit.srcSubresource.layerCount = 1;
+        blit.dstOffsets[0] = { 0, 0, 0 };
+        blit.dstOffsets[1] = { static_cast<int32_t>(dst->Width()),
+                              static_cast<int32_t>(dst->Height()),
+                              static_cast<int32_t>(dst->Depth()) };
+        blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        blit.dstSubresource.mipLevel = 0;
+        blit.dstSubresource.baseArrayLayer = 0;
+        blit.dstSubresource.layerCount = 1;
+
+        vkCmdBlitImage(this->cmdBuffer, src->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            dst->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
+            VK_FILTER_LINEAR);
+
+        this->trackedImages.push_back(src);
+        this->trackedImages.push_back(dst);
+    }
+
+    void CmdList::CopyImagesIntoCubemap(const std::array<std::shared_ptr<Image>, 6>& images,
+        std::shared_ptr<Image> cubemap) {
+        this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_ACCESS_TRANSFER_WRITE_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+        VkImageCopy imageCopy{};
+        imageCopy.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        imageCopy.srcSubresource.baseArrayLayer = 0;
+        imageCopy.srcSubresource.layerCount = 1;
+        imageCopy.srcOffset = { 0, 0, 0 };
+        imageCopy.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        imageCopy.dstSubresource.layerCount = 1;
+        imageCopy.dstOffset = { 0, 0, 0 };
+
+        uint32_t mipWidth = cubemap->Width();
+        uint32_t mipHeight = cubemap->Height();
+
+        for (size_t i = 0; i < images.size(); i++) {
+            this->TransitionImageLayout(images[i], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                VK_ACCESS_TRANSFER_READ_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT);
+        }
+
+        for (uint32_t mip = 0; mip < images[0]->Mips(); mip++) {
+            imageCopy.srcSubresource.mipLevel = mip;
+            imageCopy.dstSubresource.mipLevel = mip;
+
+            imageCopy.extent = { mipWidth, mipHeight, 1 };
+
+            for (size_t i = 0; i < images.size(); i++) {
+                imageCopy.dstSubresource.baseArrayLayer = static_cast<uint32_t>(i);
+
+                vkCmdCopyImage(this->cmdBuffer, images[i]->GetImage(),
+                    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, cubemap->GetImage(),
+                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &imageCopy);
+            }
+
+            if (mipWidth > 1)
+                mipWidth /= 2;
+            if (mipHeight > 1)
+                mipHeight /= 2;
+        }
+
+        this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            VK_ACCESS_SHADER_READ_BIT,
+            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    }
+
+    void CmdList::GenerateMips(std::shared_ptr<Image> image) {
+        VkImageMemoryBarrier barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.image = image->GetImage();
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        barrier.subresourceRange.baseArrayLayer = 0;
+        barrier.subresourceRange.layerCount = 1;
+        barrier.subresourceRange.levelCount = 1;
+
+        int32_t mipWidth = static_cast<int32_t>(image->Width());
+        int32_t mipHeight = static_cast<int32_t>(image->Height());
+        int32_t mipDepth = static_cast<int32_t>(image->Depth());
+
+        for (uint32_t i = 1; i < image->Mips(); i++) {
+            barrier.subresourceRange.baseMipLevel = i - 1;
+            barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+
+            vkCmdPipelineBarrier(this->cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1,
+                &barrier);
+
+            VkImageBlit blit{};
+            blit.srcOffsets[0] = { 0, 0, 0 };
+            blit.srcOffsets[1] = { mipWidth, mipHeight, mipDepth };
+            blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            blit.srcSubresource.mipLevel = i - 1;
+            blit.srcSubresource.baseArrayLayer = 0;
+            blit.srcSubresource.layerCount = 1;
+            blit.dstOffsets[0] = { 0, 0, 0 };
+            blit.dstOffsets[1] = { mipWidth > 1 ? mipWidth / 2 : 1,
+                                  mipHeight > 1 ? mipHeight / 2 : 1,
+                                  mipDepth > 1 ? mipDepth / 2 : 1 };
+            blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            blit.dstSubresource.mipLevel = i;
+            blit.dstSubresource.baseArrayLayer = 0;
+            blit.dstSubresource.layerCount = 1;
+
+            vkCmdBlitImage(this->cmdBuffer, image->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                image->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
+                VK_FILTER_LINEAR);
+
+            barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+            vkCmdPipelineBarrier(this->cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
+                1, &barrier);
+
+            if (mipWidth > 1)
+                mipWidth /= 2;
+            if (mipHeight > 1)
+                mipHeight /= 2;
+            if (mipDepth > 1)
+                mipDepth /= 2;
+        }
+
+        barrier.subresourceRange.baseMipLevel = image->Mips() - 1;
+        barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+        vkCmdPipelineBarrier(this->cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1,
+            &barrier);
+
+        this->trackedImages.push_back(image);
+    }
+
+    void CmdList::TransitionImageLayout(std::shared_ptr<Image> image, VkImageLayout layout,
+        VkAccessFlags access, VkPipelineStageFlags pipelineStage) {
+        ImageState imageState;
+        imageState.layout = layout;
+        imageState.accessFlags = access;
+        imageState.stageFlags = pipelineStage;
+
+        ResourceStateTracker::TransitionImage(this->cmdBuffer, *image, imageState);
+        this->trackedImages.push_back(image);
+    }
+
+    void CmdList::SetScissor(const Rect2D& rect2D) {
+        VkRect2D vkRect{};
+        vkRect.offset.x = static_cast<int32_t>(rect2D.offset.x);
+        vkRect.offset.y = static_cast<int32_t>(rect2D.offset.y);
+        vkRect.extent.width = static_cast<uint32_t>(rect2D.extent.x);
+        vkRect.extent.height = static_cast<uint32_t>(rect2D.extent.y);
+
+        vkCmdSetScissor(this->cmdBuffer, 0, 1, &vkRect);
+    }
+
+    void CmdList::SetViewport(const Rect2D& rect2D, bool normalize) {
+        VkViewport viewport{};
+        if (normalize) {
+            viewport.width = rect2D.extent.x;
+            viewport.height = -rect2D.extent.y;
+            viewport.x = rect2D.offset.x;
+            viewport.y = rect2D.offset.y - viewport.height;
+        }
+        else {
+            viewport.width = rect2D.extent.x;
+            viewport.height = rect2D.extent.y;
+            viewport.x = rect2D.offset.x;
+            viewport.y = rect2D.offset.y;
+        }
+        viewport.maxDepth = 1.0;
+
+        vkCmdSetViewport(this->cmdBuffer, 0, 1, &viewport);
+    }
+
+    void CmdList::BindVertexBuffer(std::shared_ptr<Buffer> vertexBuffer) {
+        VkBuffer vertexBuffers[] = { vertexBuffer->GetBuffer() };
+        VkDeviceSize offsets[] = { 0 };
+        vkCmdBindVertexBuffers(this->cmdBuffer, 0, 1, vertexBuffers, offsets);
+
+        this->trackedBuffers.push_back(vertexBuffer);
+    }
+
+    void CmdList::BindIndexBuffer(std::shared_ptr<Buffer> indexBuffer) {
+        vkCmdBindIndexBuffer(this->cmdBuffer, indexBuffer->GetBuffer(), 0,
+            VkIndexType::VK_INDEX_TYPE_UINT32);
+
+        this->trackedBuffers.push_back(indexBuffer);
+    }
+
+    /*void CmdList::BuildBLAS(VkAccelerationStructureGeometryKHR geometry,
+        std::shared_ptr<Buffer> scratchBuffer,
+        std::shared_ptr<Buffer> resultBuffer, VkAccelerationStructureKHR blas,
+        uint32_t indexCount) {
+        VkAccelerationStructureBuildGeometryInfoKHR buildGeometryInfo{};
+        buildGeometryInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+        buildGeometryInfo.flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+        buildGeometryInfo.geometryCount = 1;
+        buildGeometryInfo.pGeometries = &geometry;
+        buildGeometryInfo.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+        buildGeometryInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+        buildGeometryInfo.dstAccelerationStructure = blas;
+        buildGeometryInfo.scratchData.deviceAddress = scratchBuffer->GetDeviceAddress();
+
+        VkAccelerationStructureBuildRangeInfoKHR buildOffsetInfo{};
+        buildOffsetInfo.primitiveCount = indexCount / 3;
+        const VkAccelerationStructureBuildRangeInfoKHR* pBuildOffsetInfo = &buildOffsetInfo;
+
+        PFN::vkCmdBuildAccelerationStructuresKHR(this->cmdBuffer, 1, &buildGeometryInfo,
+            &pBuildOffsetInfo);
+
+        this->trackedBuffers.push_back(scratchBuffer);
+        this->trackedBuffers.push_back(resultBuffer);
+    }*/
+
+    void CmdList::BeginRenderPass(std::shared_ptr<RenderPass> renderPass,
+        const Framebuffer& framebuffer, const Color& clearColor) {
+        VkRenderPassBeginInfo renderPassInfo{};
+        renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        renderPassInfo.renderPass = renderPass->GetRenderPass();
+        renderPassInfo.framebuffer = framebuffer.GetFramebuffer();
+        renderPassInfo.renderArea.extent =
+            VkExtent2D{ framebuffer.Images()[0]->Width(), framebuffer.Images()[0]->Height() };
+
+        std::array<VkClearValue, 2> clearValues{};
+        clearValues[0].color = { {clearColor.r, clearColor.g, clearColor.b, clearColor.a} };
+        clearValues[1].depthStencil = { 1.0f, 0 };
+
+        renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
+        renderPassInfo.pClearValues = clearValues.data();
+
+        vkCmdBeginRenderPass(this->cmdBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+
+        this->trackedRenderPasses.push_back(renderPass);
+    }
+
+    void CmdList::EndRenderPass() {
+        vkCmdEndRenderPass(this->cmdBuffer);
+    }
+
+    void CmdList::BindDescriptorSet(std::shared_ptr<DescriptorSet> descriptorSet, uint32_t set,
+        VkPipelineBindPoint pipelineType) {
+        VkDescriptorSet descriptorSets[] = { descriptorSet->GetDescriptorSet() };
+
+        VkPipelineLayout layout = this->boundGraphicsPipeline->GetLayout();
+        /*VkPipelineLayout layout = (pipelineType == VK_PIPELINE_BIND_POINT_GRAPHICS)
+            ? this->boundGraphicsPipeline->GetLayout()
+            : this->boundComputePipeline->GetLayout();*/
+        vkCmdBindDescriptorSets(this->cmdBuffer, pipelineType, layout, set, 1, descriptorSets, 0,
+            nullptr);
+
+        trackedDescriptorSets.push_back(descriptorSet);
+    }
+
+    void CmdList::BindGraphicsPipeline(std::shared_ptr<GraphicsPipeline> graphicsPipeline) {
+        vkCmdBindPipeline(this->cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+            graphicsPipeline->GetPipeline());
+
+        this->boundGraphicsPipeline = graphicsPipeline;
+    }
+
+    /*void CmdList::BindComputePipeline(std::shared_ptr<ComputePipeline> computePipeline) {
+        vkCmdBindPipeline(this->cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+            computePipeline->GetPipeline());
+
+        this->boundComputePipeline = computePipeline;
+    }*/
+
+    void CmdList::Draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
+        uint32_t firstInstance) {
+        vkCmdDraw(this->cmdBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+    }
+
+    void CmdList::DrawElements(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex,
+        uint32_t firstInstance, uint32_t vertexOffset) {
+        vkCmdDrawIndexed(this->cmdBuffer, indexCount, instanceCount, firstIndex, vertexOffset,
+            firstInstance);
+    }
+
+    void CmdList::Dispatch(uint32_t x, uint32_t y, uint32_t z) {
+        vkCmdDispatch(this->cmdBuffer, x, y, z);
+    }
+
+    void CmdList::PushConstant(const std::string& name, void* constant, size_t size,
+        VkShaderStageFlags stageFlags) {
+        vkCmdPushConstants(this->cmdBuffer, this->boundGraphicsPipeline->GetLayout(),
+            stageFlags, 0, static_cast<uint32_t>(size),
+            constant);
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -394,6 +394,11 @@ namespace Vk
         vkCmdDispatch(this->cmdBuffer, x, y, z);
     }
 
+    void CmdList::TrackDescriptorSet(std::shared_ptr<DescriptorSet> descriptorSet)
+    {
+        this->trackedDescriptorSets.push_back(descriptorSet);
+    }
+
     void CmdList::PushConstant(const std::string& name, void* constant, size_t size,
         VkShaderStageFlags stageFlags) {
         vkCmdPushConstants(this->cmdBuffer, this->boundGraphicsPipeline->GetLayout(),

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -93,13 +93,27 @@ namespace Vk
         this->trackedImages.push_back(dst);
     }
 
+    void CmdList::CopyBuffers(std::shared_ptr<Image> src, std::shared_ptr<Buffer> dst, VkOffset3D offset, VkExtent3D size) {
+        VkBufferImageCopy copyRegion{};
+        copyRegion.bufferOffset = 0;
+        copyRegion.bufferRowLength = 0;
+        copyRegion.bufferImageHeight = 0;
+        copyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        copyRegion.imageSubresource.mipLevel = 0;
+        copyRegion.imageSubresource.baseArrayLayer = 0;
+        copyRegion.imageSubresource.layerCount = 1;
+        copyRegion.imageOffset = offset;
+        copyRegion.imageExtent = size;
+
+        vkCmdCopyImageToBuffer(this->cmdBuffer, src->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst->GetBuffer(), 1, &copyRegion);
+
+        this->trackedBuffers.push_back(dst);
+        this->trackedImages.push_back(src);
+    }
+
     void CmdList::CopyImages(std::shared_ptr<Image> src, std::shared_ptr<Image> dst) {
-        this->TransitionImageLayout(src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-        //    VK_ACCESS_TRANSFER_READ_BIT,
-            VK_PIPELINE_STAGE_TRANSFER_BIT);
-        this->TransitionImageLayout(dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        //    VK_ACCESS_TRANSFER_WRITE_BIT,
-            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        this->TransitionImageLayout(src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT);
+        this->TransitionImageLayout(dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT);
 
         VkImageBlit blit{};
         blit.srcOffsets[0] = { 0, 0, 0 };
@@ -129,9 +143,7 @@ namespace Vk
 
     void CmdList::CopyImagesIntoCubemap(const std::array<std::shared_ptr<Image>, 6>& images,
         std::shared_ptr<Image> cubemap) {
-        this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        //    VK_ACCESS_TRANSFER_WRITE_BIT,
-            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT);
 
         VkImageCopy imageCopy{};
         imageCopy.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -146,9 +158,7 @@ namespace Vk
         uint32_t mipHeight = cubemap->Height();
 
         for (size_t i = 0; i < images.size(); i++) {
-            this->TransitionImageLayout(images[i], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            //    VK_ACCESS_TRANSFER_READ_BIT,
-                VK_PIPELINE_STAGE_TRANSFER_BIT);
+            this->TransitionImageLayout(images[i], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT);
         }
 
         for (uint32_t mip = 0; mip < images[0]->Mips(); mip++) {
@@ -171,9 +181,7 @@ namespace Vk
                 mipHeight /= 2;
         }
 
-        this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-        //    VK_ACCESS_SHADER_READ_BIT,
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        this->TransitionImageLayout(cubemap, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
     }
 
     void CmdList::GenerateMips(std::shared_ptr<Image> image) {

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -58,6 +58,7 @@ namespace Vk
         this->trackedRenderPasses.clear();
         this->trackedBuffers.clear();
         this->trackedImages.clear();
+        this->trackedFramebuffers.clear();
         this->trackedDescriptorSets.clear();
     }
 
@@ -331,13 +332,13 @@ namespace Vk
     }*/
 
     void CmdList::BeginRenderPass(std::shared_ptr<RenderPass> renderPass,
-        const Framebuffer& framebuffer, const Color& clearColor) {
+        std::shared_ptr<Framebuffer> framebuffer, const Color& clearColor) {
         VkRenderPassBeginInfo renderPassInfo{};
         renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
         renderPassInfo.renderPass = renderPass->GetRenderPass();
-        renderPassInfo.framebuffer = framebuffer.GetFramebuffer();
+        renderPassInfo.framebuffer = framebuffer->GetFramebuffer();
         renderPassInfo.renderArea.extent =
-            VkExtent2D{ framebuffer.Images()[0]->Width(), framebuffer.Images()[0]->Height() };
+            VkExtent2D{ framebuffer->Images()[0]->Width(), framebuffer->Images()[0]->Height() };
 
         std::array<VkClearValue, 2> clearValues{};
         clearValues[0].color = { {clearColor.r, clearColor.g, clearColor.b, clearColor.a} };
@@ -349,6 +350,7 @@ namespace Vk
         vkCmdBeginRenderPass(this->cmdBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 
         this->trackedRenderPasses.push_back(renderPass);
+        this->trackedFramebuffers.push_back(framebuffer);
     }
 
     void CmdList::EndRenderPass() {

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_list.cpp
@@ -24,7 +24,7 @@ namespace Vk
         allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         allocInfo.commandBufferCount = 1;
 
-        BX_ASSERT(!vkAllocateCommandBuffers(device->GetDevice(), &allocInfo, &this->cmdBuffer),
+        VK_ASSERT(!vkAllocateCommandBuffers(device->GetDevice(), &allocInfo, &this->cmdBuffer),
             "Failed to allocate command buffer.");
     }
 
@@ -42,12 +42,12 @@ namespace Vk
         VkCommandBufferBeginInfo beginInfo{};
         beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
 
-        BX_ASSERT(!vkBeginCommandBuffer(this->cmdBuffer, &beginInfo),
+        VK_ASSERT(!vkBeginCommandBuffer(this->cmdBuffer, &beginInfo),
             "Failed to begin command buffer.");
     }
 
     void CmdList::End() {
-        BX_ASSERT(!vkEndCommandBuffer(this->cmdBuffer), "Failed to end command buffer.");
+        VK_ASSERT(!vkEndCommandBuffer(this->cmdBuffer), "Failed to end command buffer.");
     }
 
     void CmdList::Reset() {
@@ -62,7 +62,7 @@ namespace Vk
     }
 
     void CmdList::CopyBuffers(std::shared_ptr<Buffer> src, std::shared_ptr<Buffer> dst) {
-        BX_ASSERT(src->Size() == dst->Size(), "Copy buffers src and dst must have the same size.");
+        VK_ASSERT(src->Size() == dst->Size(), "Copy buffers src and dst must have the same size.");
 
         VkBufferCopy copyRegion{};
         copyRegion.size = src->Size();

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp
@@ -27,7 +27,7 @@ namespace Vk
         else
             poolInfo.queueFamilyIndex = physicalDevice.PresentFamily();
 
-        BX_ASSERT(!vkCreateCommandPool(device->GetDevice(), &poolInfo, nullptr, &this->cmdPool),
+        VK_ASSERT(!vkCreateCommandPool(device->GetDevice(), &poolInfo, nullptr, &this->cmdPool),
             "Failed to create command pool.");
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp
@@ -64,7 +64,7 @@ namespace Vk
         submitInfo.pCommandBuffers = &cmdList->cmdBuffer;
 
         if (!fence)
-            fence = std::make_shared<Fence>("Submit Cmd List", this->device);
+            fence = std::shared_ptr<Fence>(new Fence("Submit Cmd List", this->device));
         vkQueueSubmit(this->queue, 1, &submitInfo, fence->GetFence());
 
         this->busyCmdLists.push(InFlightCmdList{ fence, cmdList });

--- a/src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/cmd_queue.cpp
@@ -1,0 +1,108 @@
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/semaphore.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/fence.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    CmdQueue::CmdQueue(const std::shared_ptr<Device> device,
+        const PhysicalDevice& physicalDevice, QueueType type)
+        : device(device) {
+        vkGetDeviceQueue(device->GetDevice(), physicalDevice.GraphicsFamily(), 0, &this->queue);
+
+        VkCommandPoolCreateInfo poolInfo{};
+        poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        poolInfo.flags =
+            VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        if (type == QueueType::GRAPHICS)
+            poolInfo.queueFamilyIndex = physicalDevice.GraphicsFamily();
+        else if (type == QueueType::COMPUTE)
+            poolInfo.queueFamilyIndex = physicalDevice.ComputeFamily();
+        else
+            poolInfo.queueFamilyIndex = physicalDevice.PresentFamily();
+
+        BX_ASSERT(!vkCreateCommandPool(device->GetDevice(), &poolInfo, nullptr, &this->cmdPool),
+            "Failed to create command pool.");
+    }
+
+    CmdQueue::~CmdQueue() {
+        this->ProcessCmdLists(true);
+        std::queue<std::shared_ptr<CmdList>>().swap(this->idleCmdLists);
+
+        vkDestroyCommandPool(this->device->GetDevice(), this->cmdPool, nullptr);
+    }
+
+    void CmdQueue::SubmitCmdList(std::shared_ptr<CmdList> cmdList, std::shared_ptr<Fence> fence,
+        const List<Semaphore*>& waitSemaphores,
+        const List<VkPipelineStageFlags>& waitStages,
+        const List<Semaphore*>& signalSemaphores) {
+        cmdList->End();
+
+        std::vector<VkSemaphore> vkWaitSemaphores;
+        std::vector<VkSemaphore> vkSignalSemaphores;
+        for (auto& waitSemaphore : waitSemaphores) {
+            vkWaitSemaphores.push_back(waitSemaphore->GetSemaphore());
+        }
+        for (auto& signalSemaphore : signalSemaphores) {
+            vkSignalSemaphores.push_back(signalSemaphore->GetSemaphore());
+        }
+
+        VkSubmitInfo submitInfo{};
+        submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submitInfo.waitSemaphoreCount = static_cast<uint32_t>(vkWaitSemaphores.size());
+        submitInfo.pWaitSemaphores = vkWaitSemaphores.data();
+        submitInfo.pWaitDstStageMask = waitStages.data();
+        submitInfo.signalSemaphoreCount = static_cast<uint32_t>(vkSignalSemaphores.size());
+        submitInfo.pSignalSemaphores = vkSignalSemaphores.data();
+        submitInfo.commandBufferCount = 1;
+        submitInfo.pCommandBuffers = &cmdList->cmdBuffer;
+
+        if (!fence)
+            fence = std::make_shared<Fence>("Submit Cmd List", this->device);
+        vkQueueSubmit(this->queue, 1, &submitInfo, fence->GetFence());
+
+        this->busyCmdLists.push(InFlightCmdList{ fence, cmdList });
+    }
+
+    VkQueue CmdQueue::GetQueue() const {
+        return this->queue;
+    }
+
+    VkCommandPool CmdQueue::GetCmdPool() const {
+        return this->cmdPool;
+    }
+
+    void CmdQueue::ProcessCmdLists(bool wait) {
+        while (!this->busyCmdLists.empty()) {
+            auto busyCmdList = this->busyCmdLists.front();
+            if (busyCmdList.fence->IsComplete()) {
+                busyCmdList.cmdList->Reset();
+                this->idleCmdLists.push(busyCmdList.cmdList);
+                this->busyCmdLists.pop();
+            }
+            else if (!wait) {
+                break;
+            }
+        }
+    }
+
+    std::shared_ptr<CmdList> CmdQueue::GetCmdList() {
+        if (this->idleCmdLists.empty()) {
+            auto cmdList = std::shared_ptr<CmdList>(new CmdList(this->device, *this));
+            cmdList->Begin();
+            return cmdList;
+        }
+        else {
+            auto cmdList = this->idleCmdLists.front();
+            this->idleCmdLists.pop();
+            cmdList->Begin();
+            return cmdList;
+        }
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/compute_pipeline.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/compute_pipeline.cpp
@@ -1,0 +1,61 @@
+#include "bx/engine/modules/graphics/backend/vulkan/compute_pipeline.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/shader.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    ComputePipeline::ComputePipeline(
+        std::shared_ptr<Device> device, std::shared_ptr<Shader> shader,
+        List<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts)
+        : device(device), descriptorSetLayouts(descriptorSetLayouts) {
+        VkPipelineShaderStageCreateInfo computeShaderStageInfo{};
+        computeShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        computeShaderStageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        computeShaderStageInfo.module = shader->GetShader();
+        computeShaderStageInfo.pName = "main";
+        VkPipelineShaderStageCreateInfo shaderStages[] = { computeShaderStageInfo };
+
+        std::vector<VkDescriptorSetLayout> vkDescriptorSetLayouts{};
+        for (auto& descriptorSetLayout : descriptorSetLayouts) {
+            vkDescriptorSetLayouts.push_back(descriptorSetLayout->GetLayout());
+        }
+
+        VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+        pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        pipelineLayoutInfo.setLayoutCount = static_cast<uint32_t>(vkDescriptorSetLayouts.size());
+        pipelineLayoutInfo.pSetLayouts = vkDescriptorSetLayouts.data();
+        pipelineLayoutInfo.pushConstantRangeCount = 0;
+        pipelineLayoutInfo.pPushConstantRanges = nullptr;
+
+        VK_ASSERT(!vkCreatePipelineLayout(device->GetDevice(), &pipelineLayoutInfo, nullptr,
+            &this->pipelineLayout),
+            "Failed to create pipeline layout.");
+
+        VkComputePipelineCreateInfo pipelineInfo{};
+        pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pipelineInfo.layout = this->pipelineLayout;
+        pipelineInfo.stage = computeShaderStageInfo;
+
+        VK_ASSERT(!vkCreateComputePipelines(device->GetDevice(), VK_NULL_HANDLE, 1,
+            &pipelineInfo, nullptr, &this->pipeline),
+            "Failed to create compute pipeline.");
+    }
+
+    ComputePipeline::~ComputePipeline() {
+        vkDestroyPipeline(this->device->GetDevice(), this->pipeline, nullptr);
+        vkDestroyPipelineLayout(this->device->GetDevice(), this->pipelineLayout, nullptr);
+    }
+
+    VkPipeline ComputePipeline::GetPipeline() const {
+        return this->pipeline;
+    }
+
+    VkPipelineLayout ComputePipeline::GetLayout() const {
+        return this->pipelineLayout;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
@@ -1,0 +1,200 @@
+#include "bx/engine/modules/graphics/backend/vulkan/conversion.hpp"
+
+namespace Vk
+{
+	VkBufferUsageFlags BufferUsageFlagsToVk(BufferUsageFlags usage)
+	{
+		VkBufferUsageFlags result{};
+		if (usage & BufferUsageFlags::COPY_SRC)
+			result |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+		if (usage & BufferUsageFlags::COPY_DST)
+			result |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+		if (usage & BufferUsageFlags::INDEX)
+			result |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+		if (usage & BufferUsageFlags::VERTEX)
+			result |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+		if (usage & BufferUsageFlags::UNIFORM)
+			result |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+		if (usage & BufferUsageFlags::STORAGE)
+			result |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+		if (usage & BufferUsageFlags::INDIRECT)
+			result |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+		return result;
+	}
+
+	VkImageUsageFlags TextureUsageFlagsToVk(TextureUsageFlags usage, b8 depthFormat)
+	{
+		VkImageUsageFlags result{};
+		if (usage & TextureUsageFlags::COPY_SRC)
+			result |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+		if (usage & TextureUsageFlags::COPY_DST)
+			result |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+		if (usage & TextureUsageFlags::TEXTURE_BINDING)
+			result |= VK_IMAGE_USAGE_SAMPLED_BIT;
+		if (usage & TextureUsageFlags::STORAGE_BINDING)
+			result |= VK_IMAGE_USAGE_STORAGE_BIT;
+		if (usage & TextureUsageFlags::RENDER_ATTACHMENT)
+			result |= depthFormat ? VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT : VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+		return result;
+	}
+
+	VkFormat TextureFormatToVk(TextureFormat format)
+	{
+		switch (format)
+		{
+		case TextureFormat::R8_UNORM:
+			return VK_FORMAT_R8_UNORM;
+		case TextureFormat::R8_SNORM:
+			return VK_FORMAT_R8_SNORM;
+		case TextureFormat::R8_UINT:
+			return VK_FORMAT_R8_UINT;
+		case TextureFormat::R8_SINT:
+			return VK_FORMAT_R8_SINT;
+
+		case TextureFormat::R16_UINT:
+			return VK_FORMAT_R16_UINT;
+		case TextureFormat::R16_SINT:
+			return VK_FORMAT_R16_SINT;
+		case TextureFormat::R16_UNORM:
+			return VK_FORMAT_R16_UNORM;
+		case TextureFormat::R16_SNORM:
+			return VK_FORMAT_R16_SNORM;
+		case TextureFormat::R16_FLOAT:
+			return VK_FORMAT_R16_SFLOAT;
+		case TextureFormat::RG8_UNORM:
+			return VK_FORMAT_R8G8_UNORM;
+		case TextureFormat::RG8_SNORM:
+			return VK_FORMAT_R8G8_SNORM;
+		case TextureFormat::RG8_UINT:
+			return VK_FORMAT_R8G8_UINT;
+		case TextureFormat::RG8_SINT:
+			return VK_FORMAT_R8G8_SINT;
+
+		case TextureFormat::R32_UINT:
+			return VK_FORMAT_R32_UINT;
+		case TextureFormat::R32_SINT:
+			return VK_FORMAT_R32_SINT;
+		case TextureFormat::R32_FLOAT:
+			return VK_FORMAT_R32_SFLOAT;
+		case TextureFormat::RG16_UINT:
+			return VK_FORMAT_R16G16_UINT;
+		case TextureFormat::RG16_SINT:
+			return VK_FORMAT_R16G16_SINT;
+		case TextureFormat::RG16_UNORM:
+			return VK_FORMAT_R16G16_UNORM;
+		case TextureFormat::RG16_SNORM:
+			return VK_FORMAT_R16G16_SNORM;
+		case TextureFormat::RG16_FLOAT:
+			return VK_FORMAT_R16G16_SFLOAT;
+		case TextureFormat::RGBA8_UNORM:
+			return VK_FORMAT_R8G8B8A8_UNORM;
+		case TextureFormat::RGBA8_UNORM_SRGB:
+			return VK_FORMAT_R8G8B8A8_SRGB;
+		case TextureFormat::RGBA8_SNORM:
+			return VK_FORMAT_R8G8B8A8_SNORM;
+		case TextureFormat::RGBA8_UINT:
+			return VK_FORMAT_R8G8B8A8_UINT;
+		case TextureFormat::RGBA8_SINT:
+			return VK_FORMAT_R8G8B8A8_SINT;
+		case TextureFormat::BGRA8_UNORM:
+			return VK_FORMAT_B8G8R8A8_UNORM;
+		case TextureFormat::BGRA8_UNORM_SRGB:
+			return VK_FORMAT_B8G8R8A8_SRGB;
+
+		case TextureFormat::RGB9E5_UFLOAT:
+			return VK_FORMAT_E5B9G9R9_UFLOAT_PACK32;
+		case TextureFormat::RGB10A2_UINT:
+			return VK_FORMAT_A2R10G10B10_UINT_PACK32;
+		case TextureFormat::RGB10A2_UNORM:
+			return VK_FORMAT_A2R10G10B10_UNORM_PACK32;
+		case TextureFormat::RG11B10_FLOAT:
+			return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+
+		case TextureFormat::RG32_UINT:
+			return VK_FORMAT_R32G32_UINT;
+		case TextureFormat::RG32_SINT:
+			return VK_FORMAT_R32G32_SINT;
+		case TextureFormat::RG32_FLOAT:
+			return VK_FORMAT_R32G32_SFLOAT;
+		case TextureFormat::RGBA16_UINT:
+			return VK_FORMAT_R16G16B16A16_UINT;
+		case TextureFormat::RGBA16_SINT:
+			return VK_FORMAT_R16G16B16A16_SINT;
+		case TextureFormat::RGBA16_UNORM:
+			return VK_FORMAT_R16G16B16A16_UNORM;
+		case TextureFormat::RGBA16_SNORM:
+			return VK_FORMAT_R16G16B16A16_SNORM;
+		case TextureFormat::RGBA16_FLOAT:
+			return VK_FORMAT_R16G16B16A16_SFLOAT;
+
+		case TextureFormat::RGBA32_UINT:
+			return VK_FORMAT_R32G32B32A32_UINT;
+		case TextureFormat::RGBA32_SINT:
+			return VK_FORMAT_R32G32B32A32_SINT;
+		case TextureFormat::RGBA32_FLOAT:
+			return VK_FORMAT_R32G32B32A32_SFLOAT;
+
+		case TextureFormat::STENCIL8:
+			return VK_FORMAT_S8_UINT;
+		case TextureFormat::DEPTH16_UNORM:
+			return VK_FORMAT_D16_UNORM;
+		case TextureFormat::DEPTH24_PLUS:
+			return VK_FORMAT_D32_SFLOAT;
+		case TextureFormat::DEPTH24_PLUS_STENCIL8:
+			return VK_FORMAT_D24_UNORM_S8_UINT;
+		case TextureFormat::DEPTH32_FLOAT:
+			return VK_FORMAT_D32_SFLOAT;
+		case TextureFormat::DEPTH32_FLOAT_STENCIL8:
+			return VK_FORMAT_D32_SFLOAT_S8_UINT;
+
+		case TextureFormat::BC1_RGBA_UNORM:
+			return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+		case TextureFormat::BC1_RGBA_UNORM_SRGB:
+			return VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
+		case TextureFormat::BC2_RGBA_UNORM:
+			return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+		case TextureFormat::BC2_RGBA_UNORM_SRGB:
+			return VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
+		case TextureFormat::BC3_RGBA_UNORM:
+			return VK_FORMAT_BC1_RGB_UNORM_BLOCK;
+		case TextureFormat::BC3_RGBA_UNORM_SRGB:
+			return VK_FORMAT_BC1_RGB_SRGB_BLOCK;
+		case TextureFormat::BC4_R_UNORM:
+			return VK_FORMAT_BC4_UNORM_BLOCK;
+		case TextureFormat::BC4_R_SNORM:
+			return VK_FORMAT_BC4_SNORM_BLOCK;
+		case TextureFormat::BC5_RG_UNORM:
+			return VK_FORMAT_BC5_UNORM_BLOCK;
+		case TextureFormat::BC5_RG_SNORM:
+			return VK_FORMAT_BC5_SNORM_BLOCK;
+		case TextureFormat::BC6H_RGB_UFLOAT:
+			return VK_FORMAT_BC6H_UFLOAT_BLOCK;
+		case TextureFormat::BC6H_RGB_FLOAT:
+			return VK_FORMAT_BC6H_SFLOAT_BLOCK;
+		case TextureFormat::BC7_RGBA_UNORM:
+			return VK_FORMAT_BC7_UNORM_BLOCK;
+		case TextureFormat::BC7_RGBA_UNORM_SRGB:
+			return VK_FORMAT_BC7_SRGB_BLOCK;
+
+		default:
+			BX_FAIL("Texture format not supported.");
+			return VK_FORMAT_UNDEFINED;
+		}
+	}
+
+	VkImageType TextureDimensionToVk(TextureDimension dimension)
+	{
+		switch (dimension)
+		{
+		case TextureDimension::D1:
+			return VK_IMAGE_TYPE_1D;
+		case TextureDimension::D2:
+			return VK_IMAGE_TYPE_2D;
+		case TextureDimension::D3:
+			return VK_IMAGE_TYPE_3D;
+		default:
+			BX_FAIL("Texture dimension not supported");
+			return VK_IMAGE_TYPE_MAX_ENUM;
+		}
+	}
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
@@ -215,4 +215,38 @@ namespace Vk
 			return VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
 		}
 	}
+
+	VkDescriptorType BindingTypeToVk(BindingType type)
+	{
+		switch (type)
+		{
+		case BindingType::UNIFORM_BUFFER:
+			return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		case BindingType::STORAGE_BUFFER:
+			return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+		case BindingType::SAMPLER:
+			return VK_DESCRIPTOR_TYPE_SAMPLER;
+		case BindingType::TEXTURE:
+			return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		case BindingType::STORAGE_TEXTURE:
+			return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		case BindingType::ACCELERATION_STRUCTURE:
+			return VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+		default:
+			BX_FAIL("Binding type not supported");
+			return VK_DESCRIPTOR_TYPE_MAX_ENUM;
+		}
+	}
+
+	VkShaderStageFlags ShaderStageFlagsToVk(ShaderStageFlags stageFlags)
+	{
+		VkShaderStageFlags result{};
+		if (stageFlags & ShaderStageFlags::VERTEX)
+			result |= VK_SHADER_STAGE_VERTEX_BIT;
+		if (stageFlags & ShaderStageFlags::FRAGMENT)
+			result |= VK_SHADER_STAGE_FRAGMENT_BIT;
+		if (stageFlags & ShaderStageFlags::COMPUTE)
+			result |= VK_SHADER_STAGE_COMPUTE_BIT;
+		return result;
+	}
 }

--- a/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
@@ -197,4 +197,22 @@ namespace Vk
 			return VK_IMAGE_TYPE_MAX_ENUM;
 		}
 	}
+
+	VkShaderStageFlagBits ShaderTypeToVk(ShaderType type)
+	{
+		switch (type)
+		{
+		case ShaderType::VERTEX:
+			return VK_SHADER_STAGE_VERTEX_BIT;
+		case ShaderType::FRAGMENT:
+			return VK_SHADER_STAGE_FRAGMENT_BIT;
+		case ShaderType::GEOMETRY:
+			return VK_SHADER_STAGE_GEOMETRY_BIT;
+		case ShaderType::COMPUTE:
+			return VK_SHADER_STAGE_COMPUTE_BIT;
+		default:
+			BX_FAIL("Shader type not supported");
+			return VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
+		}
+	}
 }

--- a/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
@@ -182,6 +182,29 @@ namespace Vk
 		}
 	}
 
+	VkImageLayout TextureFormatToVkImageLayout(TextureFormat format)
+	{
+		b8 depth = IsTextureFormatDepth(format);
+		b8 stencil = IsTextureFormatStencil(format);
+
+		if (depth && stencil)
+		{
+			return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+		}
+		else if (depth)
+		{
+			return VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+		}
+		else if (stencil)
+		{
+			return VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
+		}
+		else
+		{
+			return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		}
+	}
+
 	VkImageType TextureDimensionToVk(TextureDimension dimension)
 	{
 		switch (dimension)

--- a/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/conversion.cpp
@@ -249,4 +249,76 @@ namespace Vk
 			result |= VK_SHADER_STAGE_COMPUTE_BIT;
 		return result;
 	}
+
+	VkFormat VertexFormatToVk(const VertexFormat& format)
+	{
+		switch (format)
+		{
+		case VertexFormat::UINT_8X2:
+			return VK_FORMAT_R8G8_UINT;
+		case VertexFormat::UINT_8X4:
+			return VK_FORMAT_R8G8B8A8_UINT;
+		case VertexFormat::SINT_8X2:
+			return VK_FORMAT_R8G8_SINT;
+		case VertexFormat::SINT_8X4:
+			return VK_FORMAT_R8G8B8A8_SINT;
+		case VertexFormat::UNORM_8X2:
+			return VK_FORMAT_R8G8_UNORM;
+		case VertexFormat::UNORM_8X4:
+			return VK_FORMAT_R8G8B8A8_UNORM;
+		case VertexFormat::SNORM_8X2:
+			return VK_FORMAT_R8G8_SNORM;
+		case VertexFormat::SNORM_8X4:
+			return VK_FORMAT_R8G8B8A8_SNORM;
+
+		case VertexFormat::UINT_16X2:
+			return VK_FORMAT_R16G16_UINT;
+		case VertexFormat::UINT_16X4:
+			return VK_FORMAT_R16G16B16A16_UINT;
+		case VertexFormat::SINT_16X2:
+			return VK_FORMAT_R16G16_SINT;
+		case VertexFormat::SINT_16X4:
+			return VK_FORMAT_R16G16B16A16_SINT;
+		case VertexFormat::UNORM_16X2:
+			return VK_FORMAT_R16G16_UNORM;
+		case VertexFormat::UNORM_16X4:
+			return VK_FORMAT_R16G16B16A16_UNORM;
+		case VertexFormat::SNORM_16X2:
+			return VK_FORMAT_R16G16_SNORM;
+		case VertexFormat::SNORM_16X4:
+			return VK_FORMAT_R16G16B16A16_SNORM;
+		case VertexFormat::FLOAT_16X2:
+			return VK_FORMAT_R16G16_SFLOAT;
+		case VertexFormat::FLOAT_16X4:
+			return VK_FORMAT_R16G16B16A16_SFLOAT;
+
+		case VertexFormat::FLOAT_32:
+			return VK_FORMAT_R32_SFLOAT;
+		case VertexFormat::FLOAT_32X2:
+			return VK_FORMAT_R32G32_SFLOAT;
+		case VertexFormat::FLOAT_32X3:
+			return VK_FORMAT_R32G32B32_SFLOAT;
+		case VertexFormat::FLOAT_32X4:
+			return VK_FORMAT_R32G32B32A32_SFLOAT;
+		case VertexFormat::UINT_32:
+			return VK_FORMAT_R32_UINT;
+		case VertexFormat::UINT_32X2:
+			return VK_FORMAT_R32G32_UINT;
+		case VertexFormat::UINT_32X3:
+			return VK_FORMAT_R32G32B32_UINT;
+		case VertexFormat::UINT_32X4:
+			return VK_FORMAT_R32G32B32A32_UINT;
+		case VertexFormat::SINT_32:
+			return VK_FORMAT_R32_SINT;
+		case VertexFormat::SINT_32X2:
+			return VK_FORMAT_R32G32_SINT;
+		case VertexFormat::SINT_32X3:
+			return VK_FORMAT_R32G32B32_SINT;
+		case VertexFormat::SINT_32X4:
+			return VK_FORMAT_R32G32B32A32_SINT;
+		default:
+			BX_FAIL("Vertex format not supported.");
+			return VK_FORMAT_UNDEFINED;
+		}
+	}
 }

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
@@ -1,0 +1,34 @@
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_pool.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+
+namespace Vk
+{
+    DescriptorPool::DescriptorPool(const std::shared_ptr<Device> device) : device(device) {
+        // TODO: increase this stuff based on some device limits
+        std::vector<VkDescriptorPoolSize> poolSizes = {
+            VkDescriptorPoolSize{VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 64} };
+
+        VkDescriptorPoolCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        createInfo.flags =
+            VkDescriptorPoolCreateFlagBits::VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        createInfo.maxSets = 512;
+        createInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
+        createInfo.pPoolSizes = poolSizes.data();
+
+        BX_ASSERT(
+            !vkCreateDescriptorPool(device->GetDevice(), &createInfo, nullptr, &this->pool),
+            "Failed to create descriptor pool.");
+    }
+
+    DescriptorPool::~DescriptorPool() {
+        vkDestroyDescriptorPool(this->device->GetDevice(), this->pool, nullptr);
+    }
+
+    VkDescriptorPool DescriptorPool::GetPool() const {
+        return this->pool;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
@@ -9,9 +9,11 @@ namespace Vk
 {
     DescriptorPool::DescriptorPool(const std::shared_ptr<Device> device) : device(device) {
         std::vector<VkDescriptorPoolSize> poolSizes = {
-            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1024 * 64 },
             VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1024 * 8 },
             VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_SAMPLER, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1024 * 8 },
             VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1024 * 8 },
             VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1024 * 2 }
         };
@@ -20,7 +22,7 @@ namespace Vk
         createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
         createInfo.flags =
             VkDescriptorPoolCreateFlagBits::VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-        createInfo.maxSets = 512;
+        createInfo.maxSets = 1024 * 64;
         createInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
         createInfo.pPoolSizes = poolSizes.data();
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
@@ -8,9 +8,13 @@
 namespace Vk
 {
     DescriptorPool::DescriptorPool(const std::shared_ptr<Device> device) : device(device) {
-        // TODO: increase this stuff based on some device limits
         std::vector<VkDescriptorPoolSize> poolSizes = {
-            VkDescriptorPoolSize{VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 64} };
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1024 * 8 },
+            VkDescriptorPoolSize { VkDescriptorType::VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1024 * 2 }
+        };
 
         VkDescriptorPoolCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_pool.cpp
@@ -3,6 +3,7 @@
 #include "bx/engine/core/macros.hpp"
 
 #include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
 
 namespace Vk
 {
@@ -19,7 +20,7 @@ namespace Vk
         createInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
         createInfo.pPoolSizes = poolSizes.data();
 
-        BX_ASSERT(
+        VK_ASSERT(
             !vkCreateDescriptorPool(device->GetDevice(), &createInfo, nullptr, &this->pool),
             "Failed to create descriptor pool.");
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -58,17 +58,21 @@ namespace Vk
     }
 
     void DescriptorSet::SetImage(uint32_t binding, VkDescriptorType type,
-        std::shared_ptr<Image> image, std::shared_ptr<Sampler> sampler) {
-        trackedImages[binding] = image;
+        std::shared_ptr<Image> image, std::shared_ptr<Sampler> sampler)
+    {
         trackedSamplers[binding] = sampler;
 
         VkDescriptorImageInfo imageInfo{};
         if (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
             // TODO: this assumption may break, storage images are allowed to be read in a fragment shader, query resource state tracker for accurate states
             imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+            trackedStorageImages[binding] = image;
         }
         else {
             imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            trackedSampledImages[binding] = image;
         }
         imageInfo.imageView = image->GetImageView();
         if (sampler)
@@ -85,15 +89,24 @@ namespace Vk
         vkUpdateDescriptorSets(this->device->GetDevice(), 1, &writeInfo, 0, nullptr);
     }
 
-    void DescriptorSet::TransitionResourceStates(std::shared_ptr<CmdList> cmdList) const
+    void DescriptorSet::TransitionResourceStates(std::shared_ptr<CmdList> cmdList, b8 isGraphics) const
     {
-        for (auto& image : trackedImages)
+        for (auto& image : trackedSampledImages)
         {
             if (!image) continue;
 
             VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            //VkAccessFlags accessFlags = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-            VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            VkPipelineStageFlags stageFlags = isGraphics ? VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT : VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+
+            cmdList->TransitionImageLayout(image, layout, stageFlags);
+        }
+
+        for (auto& image : trackedStorageImages)
+        {
+            if (!image) continue;
+
+            VkImageLayout layout = VK_IMAGE_LAYOUT_GENERAL;
+            VkPipelineStageFlags stageFlags = isGraphics ? VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT : VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
             cmdList->TransitionImageLayout(image, layout, stageFlags);
         }

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -24,7 +24,7 @@ namespace Vk
         allocateInfo.descriptorSetCount = 1;
         allocateInfo.pSetLayouts = vkLayouts;
 
-        BX_ASSERT(!vkAllocateDescriptorSets(device->GetDevice(), &allocateInfo, &this->descriptorSet),
+        VK_ASSERT(!vkAllocateDescriptorSets(device->GetDevice(), &allocateInfo, &this->descriptorSet),
             "Failed to allocate descriptor set.");
         DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET,
             reinterpret_cast<uint64_t>(this->descriptorSet), name);

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -91,11 +91,11 @@ namespace Vk
         {
             if (!image) continue;
 
-           /* VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            VkAccessFlags accessFlags = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-            VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+            VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            //VkAccessFlags accessFlags = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
-            cmdList->TransitionImageLayout(image, layout, accessFlags, stageFlags);*/
+            cmdList->TransitionImageLayout(image, layout, stageFlags);
         }
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -9,6 +9,7 @@
 #include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/sampler.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_list.hpp"
 
 namespace Vk
 {
@@ -81,6 +82,20 @@ namespace Vk
         writeInfo.pImageInfo = &imageInfo;
 
         vkUpdateDescriptorSets(this->device->GetDevice(), 1, &writeInfo, 0, nullptr);
+    }
+
+    void DescriptorSet::TransitionResourceStates(std::shared_ptr<CmdList> cmdList) const
+    {
+        for (auto& image : trackedImages)
+        {
+            if (!image) continue;
+
+            VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            VkAccessFlags accessFlags = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+            cmdList->TransitionImageLayout(image, layout, accessFlags, stageFlags);
+        }
     }
 
     VkDescriptorSet DescriptorSet::GetDescriptorSet() const {

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -37,6 +37,8 @@ namespace Vk
 
     void DescriptorSet::SetBuffer(uint32_t binding, VkDescriptorType type,
         std::shared_ptr<Buffer> buffer) {
+        trackedBuffers[binding] = buffer;
+
         VkDescriptorBufferInfo bufferInfo{};
         bufferInfo.buffer = buffer->GetBuffer();
         bufferInfo.offset = 0;
@@ -55,6 +57,9 @@ namespace Vk
 
     void DescriptorSet::SetImage(uint32_t binding, VkDescriptorType type,
         std::shared_ptr<Image> image, std::shared_ptr<Sampler> sampler) {
+        trackedImages[binding] = image;
+        trackedSamplers[binding] = sampler;
+
         VkDescriptorImageInfo imageInfo{};
         if (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
             // TODO: this assumption may break, storage images are allowed to be read in a fragment shader, query resource state tracker for accurate states

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -1,0 +1,84 @@
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_pool.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/buffer.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/sampler.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    DescriptorSet::DescriptorSet(const String& name, const std::shared_ptr<Device> device,
+        const std::shared_ptr<DescriptorPool> pool,
+        const std::shared_ptr<DescriptorSetLayout> layout)
+        : device(device), pool(pool), layout(layout) {
+        VkDescriptorSetLayout vkLayouts[] = { layout->GetLayout() };
+
+        VkDescriptorSetAllocateInfo allocateInfo{};
+        allocateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        allocateInfo.descriptorPool = pool->GetPool();
+        allocateInfo.descriptorSetCount = 1;
+        allocateInfo.pSetLayouts = vkLayouts;
+
+        BX_ASSERT(!vkAllocateDescriptorSets(device->GetDevice(), &allocateInfo, &this->descriptorSet),
+            "Failed to allocate descriptor set.");
+        DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET,
+            reinterpret_cast<uint64_t>(this->descriptorSet), name);
+    }
+
+    DescriptorSet::~DescriptorSet() {
+        vkFreeDescriptorSets(this->device->GetDevice(), this->pool->GetPool(), 1,
+            &this->descriptorSet);
+    }
+
+    void DescriptorSet::SetBuffer(uint32_t binding, VkDescriptorType type,
+        std::shared_ptr<Buffer> buffer) {
+        VkDescriptorBufferInfo bufferInfo{};
+        bufferInfo.buffer = buffer->GetBuffer();
+        bufferInfo.offset = 0;
+        bufferInfo.range = buffer->Size();
+
+        VkWriteDescriptorSet writeInfo{};
+        writeInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writeInfo.dstSet = this->descriptorSet;
+        writeInfo.dstBinding = binding;
+        writeInfo.descriptorCount = 1;
+        writeInfo.descriptorType = type;
+        writeInfo.pBufferInfo = &bufferInfo;
+
+        vkUpdateDescriptorSets(this->device->GetDevice(), 1, &writeInfo, 0, nullptr);
+    }
+
+    void DescriptorSet::SetImage(uint32_t binding, VkDescriptorType type,
+        std::shared_ptr<Image> image, std::shared_ptr<Sampler> sampler) {
+        VkDescriptorImageInfo imageInfo{};
+        if (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+            // TODO: this assumption may break, storage images are allowed to be read in a fragment shader, query resource state tracker for accurate states
+            imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+        }
+        else {
+            imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        }
+        imageInfo.imageView = image->GetImageView();
+        if (sampler)
+            imageInfo.sampler = sampler->GetSampler();
+
+        VkWriteDescriptorSet writeInfo{};
+        writeInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writeInfo.dstSet = this->descriptorSet;
+        writeInfo.dstBinding = binding;
+        writeInfo.descriptorCount = 1;
+        writeInfo.descriptorType = type;
+        writeInfo.pImageInfo = &imageInfo;
+
+        vkUpdateDescriptorSets(this->device->GetDevice(), 1, &writeInfo, 0, nullptr);
+    }
+
+    VkDescriptorSet DescriptorSet::GetDescriptorSet() const {
+        return this->descriptorSet;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set.cpp
@@ -27,6 +27,7 @@ namespace Vk
 
         VK_ASSERT(!vkAllocateDescriptorSets(device->GetDevice(), &allocateInfo, &this->descriptorSet),
             "Failed to allocate descriptor set.");
+
         DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET,
             reinterpret_cast<uint64_t>(this->descriptorSet), name);
     }
@@ -90,11 +91,11 @@ namespace Vk
         {
             if (!image) continue;
 
-            VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+           /* VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
             VkAccessFlags accessFlags = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
             VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
-            cmdList->TransitionImageLayout(image, layout, accessFlags, stageFlags);
+            cmdList->TransitionImageLayout(image, layout, accessFlags, stageFlags);*/
         }
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
@@ -1,0 +1,32 @@
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    DescriptorSetLayout::DescriptorSetLayout(const String& name, const std::shared_ptr<Device> device,
+        const List<VkDescriptorSetLayoutBinding>& bindings)
+        : device(device) {
+        VkDescriptorSetLayoutCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        createInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+        createInfo.pBindings = bindings.data();
+
+        BX_ASSERT(
+            !vkCreateDescriptorSetLayout(device->GetDevice(), &createInfo, nullptr, &this->layout),
+            "Failed to create descriptor set layout.");
+        DebugNames::Set(*device, VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, reinterpret_cast<uint64_t>(this->layout),
+            name);
+    }
+
+    DescriptorSetLayout::~DescriptorSetLayout() {
+        vkDestroyDescriptorSetLayout(this->device->GetDevice(), this->layout, nullptr);
+    }
+
+    VkDescriptorSetLayout DescriptorSetLayout::GetLayout() const {
+        return this->layout;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
@@ -20,6 +20,11 @@ namespace Vk
             "Failed to create descriptor set layout.");
         DebugNames::Set(*device, VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, reinterpret_cast<uint64_t>(this->layout),
             name);
+
+        for (auto& binding : bindings)
+        {
+            descriptorTypes[binding.binding] = binding.descriptorType;
+        }
     }
 
     DescriptorSetLayout::~DescriptorSetLayout() {
@@ -28,19 +33,29 @@ namespace Vk
     }
     
     DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout&& other) noexcept
-        : layout(other.layout), device(other.device)
+        : layout(other.layout), device(other.device), descriptorTypes(other.descriptorTypes)
     {
         other.layout = VK_NULL_HANDLE;
+        other.descriptorTypes.clear();
     }
 
     DescriptorSetLayout& DescriptorSetLayout::operator=(DescriptorSetLayout&& other) noexcept
     {
         layout = other.layout;
+        descriptorTypes = other.descriptorTypes;
         other.layout = VK_NULL_HANDLE;
+        other.descriptorTypes.clear();
         return *this;
     }
 
     VkDescriptorSetLayout DescriptorSetLayout::GetLayout() const {
         return this->layout;
+    }
+
+    VkDescriptorType DescriptorSetLayout::GetDescriptorType(u32 binding) const
+    {
+        auto typeIter = descriptorTypes.find(binding);
+        BX_ENSURE(typeIter != descriptorTypes.end());
+        return typeIter->second;
     }
 }

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
@@ -23,7 +23,21 @@ namespace Vk
     }
 
     DescriptorSetLayout::~DescriptorSetLayout() {
-        vkDestroyDescriptorSetLayout(this->device->GetDevice(), this->layout, nullptr);
+        if (this->layout != VK_NULL_HANDLE)
+            vkDestroyDescriptorSetLayout(this->device->GetDevice(), this->layout, nullptr);
+    }
+    
+    DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout&& other) noexcept
+        : layout(other.layout), device(other.device)
+    {
+        other.layout = VK_NULL_HANDLE;
+    }
+
+    DescriptorSetLayout& DescriptorSetLayout::operator=(DescriptorSetLayout&& other) noexcept
+    {
+        layout = other.layout;
+        other.layout = VK_NULL_HANDLE;
+        return *this;
     }
 
     VkDescriptorSetLayout DescriptorSetLayout::GetLayout() const {

--- a/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.cpp
@@ -15,7 +15,7 @@ namespace Vk
         createInfo.bindingCount = static_cast<uint32_t>(bindings.size());
         createInfo.pBindings = bindings.data();
 
-        BX_ASSERT(
+        VK_ASSERT(
             !vkCreateDescriptorSetLayout(device->GetDevice(), &createInfo, nullptr, &this->layout),
             "Failed to create descriptor set layout.");
         DebugNames::Set(*device, VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, reinterpret_cast<uint64_t>(this->layout),

--- a/src/bx/engine/modules/graphics/backend/vulkan/device.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/device.cpp
@@ -1,0 +1,98 @@
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/extensions.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+#define VMA_IMPLEMENTATION
+#include <vk_mem_alloc.h>
+
+namespace Vk
+{
+    Device::Device(std::shared_ptr<Instance> instance,
+        const PhysicalDevice& physicalDevice, bool debug)
+        : instance(instance) {
+        VkDeviceQueueCreateInfo queueCreateInfo{};
+        queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueCreateInfo.queueFamilyIndex = physicalDevice.GraphicsFamily();
+        queueCreateInfo.queueCount = 1;
+        float queuePriority = 1.0;
+        queueCreateInfo.pQueuePriorities = &queuePriority;
+
+        VkPhysicalDeviceFeatures deviceFeatures{};
+        deviceFeatures.fillModeNonSolid = VK_TRUE;
+        deviceFeatures.samplerAnisotropy = VK_TRUE;
+
+        VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{};
+        accelerationStructureFeatures.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
+        accelerationStructureFeatures.accelerationStructure = true;
+
+        VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bufferDeviceAddressFeatures{};
+        bufferDeviceAddressFeatures.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
+        bufferDeviceAddressFeatures.bufferDeviceAddress = true;
+        bufferDeviceAddressFeatures.bufferDeviceAddressCaptureReplay = true;
+
+        if (physicalDevice.RayTracingSuitable()) {
+            bufferDeviceAddressFeatures.pNext = &accelerationStructureFeatures;
+        }
+
+        VkDeviceCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        if (physicalDevice.RayTracingSuitable()) {
+            createInfo.pNext = &bufferDeviceAddressFeatures;
+        }
+        createInfo.pQueueCreateInfos = &queueCreateInfo;
+        createInfo.queueCreateInfoCount = 1;
+        createInfo.pEnabledFeatures = &deviceFeatures;
+        createInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
+        createInfo.ppEnabledExtensionNames = deviceExtensions.data();
+
+        if (debug) {
+            createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());
+            createInfo.ppEnabledLayerNames = validationLayers.data();
+        }
+        else {
+            createInfo.enabledLayerCount = 0;
+        }
+
+        BX_ASSERT(!vkCreateDevice(physicalDevice.GetPhysicalDevice(), &createInfo, nullptr,
+            &this->device),
+            "Failed to create logical device.");
+        VmaAllocatorCreateInfo vmaCreateInfo{};
+        vmaCreateInfo.vulkanApiVersion = VULKAN_VERSION;
+        vmaCreateInfo.instance = instance->GetInstance();
+        vmaCreateInfo.physicalDevice = physicalDevice.GetPhysicalDevice();
+        vmaCreateInfo.device = this->device;
+        // NOTE: these will need to be loaded on some platforms, just like the core vulkan functions
+        vmaCreateInfo.pVulkanFunctions = nullptr;
+        if (physicalDevice.RayTracingSuitable()) {
+            vmaCreateInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+        }
+
+        BX_ASSERT(!vmaCreateAllocator(&vmaCreateInfo, &this->allocator),
+            "Failed to create allocator.");
+    }
+
+    Device::~Device() {
+        this->WaitIdle();
+        vmaDestroyAllocator(this->allocator);
+        vkDestroyDevice(this->device, nullptr);
+    }
+
+    void Device::WaitIdle() const {
+        vkDeviceWaitIdle(this->device);
+    }
+
+    VkDevice Device::GetDevice() const {
+        return this->device;
+    }
+
+    VmaAllocator Device::GetAllocator() const {
+        return this->allocator;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/device.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/device.cpp
@@ -60,7 +60,7 @@ namespace Vk
             createInfo.enabledLayerCount = 0;
         }
 
-        BX_ASSERT(!vkCreateDevice(physicalDevice.GetPhysicalDevice(), &createInfo, nullptr,
+        VK_ASSERT(!vkCreateDevice(physicalDevice.GetPhysicalDevice(), &createInfo, nullptr,
             &this->device),
             "Failed to create logical device.");
         VmaAllocatorCreateInfo vmaCreateInfo{};
@@ -74,7 +74,7 @@ namespace Vk
             vmaCreateInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
         }
 
-        BX_ASSERT(!vmaCreateAllocator(&vmaCreateInfo, &this->allocator),
+        VK_ASSERT(!vmaCreateAllocator(&vmaCreateInfo, &this->allocator),
             "Failed to create allocator.");
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/device.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/device.cpp
@@ -41,6 +41,12 @@ namespace Vk
             bufferDeviceAddressFeatures.pNext = &accelerationStructureFeatures;
         }
 
+        List<const char*> extensions = deviceExtensions;
+        if (physicalDevice.RayTracingSuitable())
+        {
+            extensions.insert(extensions.end(), deviceRaytracingExtensions.begin(), deviceRaytracingExtensions.end());
+        }
+
         VkDeviceCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
         if (physicalDevice.RayTracingSuitable()) {
@@ -49,8 +55,8 @@ namespace Vk
         createInfo.pQueueCreateInfos = &queueCreateInfo;
         createInfo.queueCreateInfoCount = 1;
         createInfo.pEnabledFeatures = &deviceFeatures;
-        createInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
-        createInfo.ppEnabledExtensionNames = deviceExtensions.data();
+        createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
+        createInfo.ppEnabledExtensionNames = extensions.data();
 
         if (debug) {
             createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());

--- a/src/bx/engine/modules/graphics/backend/vulkan/extensions.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/extensions.cpp
@@ -1,0 +1,75 @@
+#include "bx/engine/modules/graphics/backend/vulkan/extensions.hpp"
+
+#include "bx/engine/containers/string.hpp"
+#include "bx/engine/containers/hash_set.hpp"
+#include "bx/engine/core/macros.hpp"
+
+namespace Vk
+{
+    bool CheckDeviceExtensionSupport(VkPhysicalDevice physicalDevice) {
+        uint32_t extensionCount;
+        vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount, nullptr);
+        std::vector<VkExtensionProperties> availableExtensions(extensionCount);
+        vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount,
+            availableExtensions.data());
+
+        HashSet<String> requiredExtensions(deviceExtensions.begin(), deviceExtensions.end());
+
+        for (const auto& extension : availableExtensions) {
+            requiredExtensions.erase(extension.extensionName);
+        }
+
+        bool supported = requiredExtensions.empty();
+        if (!supported) {
+            BX_LOGW("Missing device extensions:");
+            for (auto& extension : requiredExtensions) {
+                BX_LOGW("%s", extension.c_str());
+            }
+        }
+
+        return supported;
+    }
+
+    bool CheckDeviceRaytracingExtensionSupport(VkPhysicalDevice physicalDevice) {
+        uint32_t extensionCount;
+        vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount, nullptr);
+        std::vector<VkExtensionProperties> availableExtensions(extensionCount);
+        vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount,
+            availableExtensions.data());
+
+        HashSet<String> requiredExtensions(deviceRaytracingExtensions.begin(),
+            deviceRaytracingExtensions.end());
+
+        for (const auto& extension : availableExtensions) {
+            requiredExtensions.erase(extension.extensionName);
+        }
+
+        bool supported = requiredExtensions.empty();
+        if (!supported) {
+            BX_LOGW("Missing device extensions:");
+            for (auto& extension : requiredExtensions) {
+                BX_LOGW("%s", extension.c_str());
+            }
+        }
+
+        return supported;
+    }
+
+#if defined BX_PLATFORM_PC || defined BX_PLATFORM_LINUX
+    List<const char*> PlatformInstanceExtensions() {
+        std::vector<const char*> extensions{};
+
+#ifdef BX_WINDOW_GLFW_BACKEND
+        uint32_t glfwExtensionCount = 0;
+        const char** ppGlfwExtensions;
+        ppGlfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
+        extensions.resize(glfwExtensionCount);
+        for (size_t i = 0; i < static_cast<size_t>(glfwExtensionCount); i++) {
+            extensions[i] = ppGlfwExtensions[i];
+        }
+#endif
+
+        return extensions;
+    }
+#endif
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/fence.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/fence.cpp
@@ -12,7 +12,7 @@ namespace Vk
         createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         createInfo.flags = signaled ? VkFenceCreateFlagBits::VK_FENCE_CREATE_SIGNALED_BIT : 0;
 
-        BX_ASSERT(!vkCreateFence(device->GetDevice(), &createInfo, nullptr, &this->fence),
+        VK_ASSERT(!vkCreateFence(device->GetDevice(), &createInfo, nullptr, &this->fence),
             "Failed to create fence.");
         DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_FENCE,
             reinterpret_cast<uint64_t>(this->fence), name);

--- a/src/bx/engine/modules/graphics/backend/vulkan/fence.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/fence.cpp
@@ -1,0 +1,53 @@
+#include "bx/engine/modules/graphics/backend/vulkan/fence.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    Fence::Fence(const String& name, std::shared_ptr<Device> device, bool signaled) : device(device) {
+        VkFenceCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        createInfo.flags = signaled ? VkFenceCreateFlagBits::VK_FENCE_CREATE_SIGNALED_BIT : 0;
+
+        BX_ASSERT(!vkCreateFence(device->GetDevice(), &createInfo, nullptr, &this->fence),
+            "Failed to create fence.");
+        DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_FENCE,
+            reinterpret_cast<uint64_t>(this->fence), name);
+    }
+
+    Fence::Fence(Fence&& other) noexcept : fence(other.fence), device(other.device) {
+        other.fence = VK_NULL_HANDLE;
+    }
+
+    Fence& Fence::operator=(Fence&& other) noexcept {
+        this->fence = other.fence;
+        other.fence = VK_NULL_HANDLE;
+        return *this;
+    }
+
+    Fence::~Fence() {
+        if (this->fence) {
+            vkDestroyFence(this->device->GetDevice(), this->fence, nullptr);
+        }
+    }
+
+    bool Fence::IsComplete() const {
+        return vkGetFenceStatus(this->device->GetDevice(), this->fence) == VK_SUCCESS;
+    }
+
+    void Fence::Wait() const {
+        vkWaitForFences(this->device->GetDevice(), 1, &this->fence, true,
+            std::numeric_limits<uint64_t>::max());
+    }
+
+    void Fence::Reset() {
+        vkResetFences(this->device->GetDevice(), 1, &this->fence);
+    }
+
+    VkFence Fence::GetFence() const {
+        return this->fence;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp
@@ -1,0 +1,69 @@
+#include "bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    Framebuffer::Framebuffer(const String& name, std::shared_ptr<Device> device,
+        List<std::shared_ptr<Image>> images,
+        std::shared_ptr<RenderPass> renderPass)
+        : renderPass(renderPass), images(images), device(device) {
+        BX_ASSERT(images.size() > 0, "Framebuffer requires at least 1 image.");
+
+        std::vector<VkImageView> attachments;
+        for (auto image : images) {
+            attachments.push_back(image->GetImageView());
+        }
+
+        VkFramebufferCreateInfo framebufferInfo{};
+        framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        framebufferInfo.renderPass = renderPass->GetRenderPass();
+        framebufferInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+        framebufferInfo.pAttachments = attachments.data();
+        framebufferInfo.width = images[0]->Width();
+        framebufferInfo.height = images[0]->Height();
+        framebufferInfo.layers = 1;
+
+        BX_ASSERT(!vkCreateFramebuffer(this->device->GetDevice(), &framebufferInfo, nullptr,
+            &this->framebuffer),
+            "Failed to create frame buffer.");
+
+        DebugNames::Set(*device, VK_OBJECT_TYPE_FRAMEBUFFER, reinterpret_cast<uint64_t>(this->framebuffer),
+            name);
+    }
+
+    Framebuffer::Framebuffer(Framebuffer&& other) noexcept
+        : framebuffer(other.framebuffer),
+        renderPass(other.renderPass),
+        images(other.images),
+        device(other.device) {
+        other.framebuffer = VK_NULL_HANDLE;
+    }
+
+    Framebuffer& Framebuffer::operator=(Framebuffer&& other) noexcept {
+        this->framebuffer = other.framebuffer;
+        this->renderPass = other.renderPass;
+        this->images = other.images;
+        other.framebuffer = VK_NULL_HANDLE;
+        return *this;
+    }
+
+    Framebuffer::~Framebuffer() {
+        if (this->framebuffer) {
+            vkDestroyFramebuffer(this->device->GetDevice(), this->framebuffer, nullptr);
+        }
+    }
+
+    const List<std::shared_ptr<Image>>& Framebuffer::Images() const {
+        return this->images;
+    }
+
+    VkFramebuffer Framebuffer::GetFramebuffer() const {
+        return this->framebuffer;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp
@@ -10,9 +10,8 @@
 namespace Vk
 {
     Framebuffer::Framebuffer(const String& name, std::shared_ptr<Device> device,
-        List<std::shared_ptr<Image>> images,
-        std::shared_ptr<RenderPass> renderPass)
-        : renderPass(renderPass), images(images), device(device) {
+        const FramebufferInfo& info)
+        : renderPass(info.renderPass), images(info.images), device(device) {
         VK_ASSERT(images.size() > 0, "Framebuffer requires at least 1 image.");
 
         std::vector<VkImageView> attachments;

--- a/src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/framebuffer.cpp
@@ -13,7 +13,7 @@ namespace Vk
         List<std::shared_ptr<Image>> images,
         std::shared_ptr<RenderPass> renderPass)
         : renderPass(renderPass), images(images), device(device) {
-        BX_ASSERT(images.size() > 0, "Framebuffer requires at least 1 image.");
+        VK_ASSERT(images.size() > 0, "Framebuffer requires at least 1 image.");
 
         std::vector<VkImageView> attachments;
         for (auto image : images) {
@@ -29,7 +29,7 @@ namespace Vk
         framebufferInfo.height = images[0]->Height();
         framebufferInfo.layers = 1;
 
-        BX_ASSERT(!vkCreateFramebuffer(this->device->GetDevice(), &framebufferInfo, nullptr,
+        VK_ASSERT(!vkCreateFramebuffer(this->device->GetDevice(), &framebufferInfo, nullptr,
             &this->framebuffer),
             "Failed to create frame buffer.");
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
@@ -1,0 +1,179 @@
+#include "bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/descriptor_set_layout.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/shader.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    GraphicsPipeline::GraphicsPipeline(
+        std::shared_ptr<Device> device, const std::vector<const Shader*>& shaders,
+        std::shared_ptr<RenderPass> renderPass,
+        std::vector<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts,
+        std::vector<PushConstantRange> pushConstants, GraphicsPipelineInfo info)
+        : info(info),
+        device(device),
+        renderPass(renderPass),
+        descriptorSetLayouts(descriptorSetLayouts) {
+        // TODO: make more dynamic
+        VkPipelineShaderStageCreateInfo vertShaderStageInfo{};
+        vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        vertShaderStageInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
+        vertShaderStageInfo.module = shaders[0]->GetShader();
+        vertShaderStageInfo.pName = "main";
+        VkPipelineShaderStageCreateInfo fragShaderStageInfo{};
+        fragShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        fragShaderStageInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+        fragShaderStageInfo.module = shaders[1]->GetShader();
+        fragShaderStageInfo.pName = "main";
+        VkPipelineShaderStageCreateInfo shaderStages[] = { vertShaderStageInfo, fragShaderStageInfo };
+
+        std::vector<VkDynamicState> dynamicStates = { VK_DYNAMIC_STATE_VIEWPORT,
+                                                     VK_DYNAMIC_STATE_SCISSOR };
+        VkPipelineDynamicStateCreateInfo dynamicState{};
+        dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+        dynamicState.dynamicStateCount = static_cast<uint32_t>(dynamicStates.size());
+        dynamicState.pDynamicStates = dynamicStates.data();
+
+        // TODO: flexible vertex layouts
+        VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
+        /*auto vertexBindingDescription = VertexBindingDescription();
+        auto vertexAttributeDescriptions = VertexAttributeDescriptions();*/
+        vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+        /*if (info.inputVertices) {
+            vertexInputInfo.vertexBindingDescriptionCount = 1;
+            vertexInputInfo.pVertexBindingDescriptions = &vertexBindingDescription;
+            vertexInputInfo.vertexAttributeDescriptionCount =
+                static_cast<uint32_t>(vertexAttributeDescriptions.size());
+            vertexInputInfo.pVertexAttributeDescriptions = vertexAttributeDescriptions.data();
+        }*/
+
+        VkPipelineInputAssemblyStateCreateInfo inputAssembly{};
+        inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+        inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        inputAssembly.primitiveRestartEnable = VK_FALSE;
+
+        VkPipelineRasterizationStateCreateInfo rasterizer{};
+        rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+        rasterizer.depthClampEnable = VK_FALSE;
+        rasterizer.rasterizerDiscardEnable = VK_FALSE;
+        rasterizer.polygonMode = info.polygonMode;
+        rasterizer.cullMode = info.culling ? VK_CULL_MODE_BACK_BIT : VK_CULL_MODE_NONE;
+        rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+        rasterizer.depthBiasEnable = VK_FALSE;
+        rasterizer.lineWidth = 1.0;
+
+        VkPipelineMultisampleStateCreateInfo multisampling{};
+        multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+        multisampling.sampleShadingEnable = VK_FALSE;
+        multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+        VkPipelineColorBlendAttachmentState colorBlendAttachment{};
+        colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+            VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+        colorBlendAttachment.blendEnable = info.blending;
+        if (info.blending) {
+            colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+            colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+            colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+            colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+            colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+            colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+        }
+
+        VkPipelineColorBlendStateCreateInfo colorBlending{};
+        colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+        colorBlending.logicOpEnable = VK_FALSE;
+        colorBlending.attachmentCount = 1;
+        colorBlending.pAttachments = &colorBlendAttachment;
+
+        std::vector<VkPushConstantRange> vkPushConstantRanges{};
+        for (auto& pushConstantRange : pushConstants) {
+            VkPushConstantRange vkPushConstantRange{};
+            vkPushConstantRange.size = static_cast<uint32_t>(pushConstantRange.size);
+            vkPushConstantRange.stageFlags = pushConstantRange.stageFlags;
+            vkPushConstantRanges.push_back(vkPushConstantRange);
+        }
+
+        std::vector<VkDescriptorSetLayout> vkDescriptorSetLayouts{};
+        for (auto& descriptorSetLayout : descriptorSetLayouts) {
+            vkDescriptorSetLayouts.push_back(descriptorSetLayout->GetLayout());
+        }
+
+        VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+        pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        pipelineLayoutInfo.setLayoutCount = static_cast<uint32_t>(vkDescriptorSetLayouts.size());
+        pipelineLayoutInfo.pSetLayouts = vkDescriptorSetLayouts.data();
+        pipelineLayoutInfo.pushConstantRangeCount =
+            static_cast<uint32_t>(vkPushConstantRanges.size());
+        pipelineLayoutInfo.pPushConstantRanges = vkPushConstantRanges.data();
+
+        BX_ASSERT(!vkCreatePipelineLayout(device->GetDevice(), &pipelineLayoutInfo, nullptr,
+            &this->pipelineLayout),
+            "Failed to create pipeline layout.");
+
+        VkViewport viewport{};
+        viewport.x = 0.0f;
+        viewport.y = 0.0f;
+        viewport.width = 0.0f;
+        viewport.height = 0.0f;
+        viewport.minDepth = 0.0f;
+        viewport.maxDepth = 1.0f;
+
+        VkRect2D scissor{};
+        scissor.offset = { 0, 0 };
+        scissor.extent = { 0, 0 };
+
+        VkPipelineViewportStateCreateInfo viewportState{};
+        viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+        viewportState.viewportCount = 1;
+        viewportState.pViewports = &viewport;
+        viewportState.scissorCount = 1;
+        viewportState.pScissors = &scissor;
+
+        VkPipelineDepthStencilStateCreateInfo depthStencil{};
+        depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+        depthStencil.depthTestEnable = !info.ignoreDepth;
+        depthStencil.depthWriteEnable = !info.ignoreDepth;
+        depthStencil.depthCompareOp = VK_COMPARE_OP_LESS;
+        depthStencil.depthBoundsTestEnable = VK_FALSE;
+        depthStencil.stencilTestEnable = VK_FALSE;
+
+        VkGraphicsPipelineCreateInfo pipelineInfo{};
+        pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+        pipelineInfo.stageCount = 2;
+        pipelineInfo.pStages = shaderStages;
+        pipelineInfo.pVertexInputState = &vertexInputInfo;
+        pipelineInfo.pInputAssemblyState = &inputAssembly;
+        pipelineInfo.pViewportState = &viewportState;
+        pipelineInfo.pRasterizationState = &rasterizer;
+        pipelineInfo.pMultisampleState = &multisampling;
+        pipelineInfo.pDepthStencilState = &depthStencil;
+        pipelineInfo.pColorBlendState = &colorBlending;
+        pipelineInfo.pDynamicState = &dynamicState;
+        pipelineInfo.layout = this->pipelineLayout;
+        pipelineInfo.renderPass = renderPass->GetRenderPass();
+        pipelineInfo.subpass = 0;
+
+        BX_ASSERT(!vkCreateGraphicsPipelines(device->GetDevice(), VK_NULL_HANDLE, 1, &pipelineInfo,
+            nullptr, &this->pipeline),
+            "Failed to create graphics pipeline.");
+    }
+
+    GraphicsPipeline::~GraphicsPipeline() {
+        vkDestroyPipeline(this->device->GetDevice(), this->pipeline, nullptr);
+        vkDestroyPipelineLayout(this->device->GetDevice(), this->pipelineLayout, nullptr);
+    }
+
+    VkPipeline GraphicsPipeline::GetPipeline() const {
+        return this->pipeline;
+    }
+
+    VkPipelineLayout GraphicsPipeline::GetLayout() const {
+        return this->pipelineLayout;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
@@ -40,18 +40,12 @@ namespace Vk
         dynamicState.dynamicStateCount = static_cast<uint32_t>(dynamicStates.size());
         dynamicState.pDynamicStates = dynamicStates.data();
 
-        // TODO: flexible vertex layouts
         VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
-        /*auto vertexBindingDescription = VertexBindingDescription();
-        auto vertexAttributeDescriptions = VertexAttributeDescriptions();*/
         vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-        /*if (info.inputVertices) {
-            vertexInputInfo.vertexBindingDescriptionCount = 1;
-            vertexInputInfo.pVertexBindingDescriptions = &vertexBindingDescription;
-            vertexInputInfo.vertexAttributeDescriptionCount =
-                static_cast<uint32_t>(vertexAttributeDescriptions.size());
-            vertexInputInfo.pVertexAttributeDescriptions = vertexAttributeDescriptions.data();
-        }*/
+        vertexInputInfo.vertexBindingDescriptionCount = info.vertexBindingDescriptions.size();
+        vertexInputInfo.pVertexBindingDescriptions = info.vertexBindingDescriptions.data();
+        vertexInputInfo.vertexAttributeDescriptionCount = info.vertexAttributeDescriptions.size();
+        vertexInputInfo.pVertexAttributeDescriptions = info.vertexAttributeDescriptions.data();
 
         VkPipelineInputAssemblyStateCreateInfo inputAssembly{};
         inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;

--- a/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
@@ -112,7 +112,7 @@ namespace Vk
             static_cast<uint32_t>(vkPushConstantRanges.size());
         pipelineLayoutInfo.pPushConstantRanges = vkPushConstantRanges.data();
 
-        BX_ASSERT(!vkCreatePipelineLayout(device->GetDevice(), &pipelineLayoutInfo, nullptr,
+        VK_ASSERT(!vkCreatePipelineLayout(device->GetDevice(), &pipelineLayoutInfo, nullptr,
             &this->pipelineLayout),
             "Failed to create pipeline layout.");
 
@@ -159,7 +159,7 @@ namespace Vk
         pipelineInfo.renderPass = renderPass->GetRenderPass();
         pipelineInfo.subpass = 0;
 
-        BX_ASSERT(!vkCreateGraphicsPipelines(device->GetDevice(), VK_NULL_HANDLE, 1, &pipelineInfo,
+        VK_ASSERT(!vkCreateGraphicsPipelines(device->GetDevice(), VK_NULL_HANDLE, 1, &pipelineInfo,
             nullptr, &this->pipeline),
             "Failed to create graphics pipeline.");
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
@@ -1,4 +1,3 @@
-
 #include "bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp"
 
 #include "bx/engine/core/macros.hpp"

--- a/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.cpp
@@ -1,3 +1,4 @@
+
 #include "bx/engine/modules/graphics/backend/vulkan/graphics_pipeline.hpp"
 
 #include "bx/engine/core/macros.hpp"
@@ -13,7 +14,7 @@ namespace Vk
     GraphicsPipeline::GraphicsPipeline(
         std::shared_ptr<Device> device, const std::vector<const Shader*>& shaders,
         std::shared_ptr<RenderPass> renderPass,
-        std::vector<std::shared_ptr<DescriptorSetLayout>> descriptorSetLayouts,
+        const std::vector<std::shared_ptr<DescriptorSetLayout>>& descriptorSetLayouts,
         std::vector<PushConstantRange> pushConstants, GraphicsPipelineInfo info)
         : info(info),
         device(device),

--- a/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
@@ -38,7 +38,7 @@ namespace Vk
         const PhysicalDevice& physicalDevice, uint32_t width, uint32_t height,
         uint32_t mips, VkImageUsageFlags usage, VkFormat format, uint32_t arrayLayers,
         VkImageType dims, unsigned depth)
-        : device(device),
+        : name(name), device(device),
         imageView(VK_NULL_HANDLE),
         width(width),
         height(height),
@@ -99,7 +99,7 @@ namespace Vk
 
     Image::Image(const String& name, std::shared_ptr<Device> device, VkImage image, VkImageView imageView,
         uint32_t width, uint32_t height)
-        : device(device),
+        : name(name), device(device),
         image(image),
         imageView(imageView),
         allocation(VK_NULL_HANDLE),

--- a/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
@@ -65,7 +65,7 @@ namespace Vk
         VmaAllocationCreateInfo allocCreateInfo{};
         allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
 
-        BX_ASSERT(!vmaCreateImage(device->GetAllocator(), &createInfo, &allocCreateInfo,
+        VK_ASSERT(!vmaCreateImage(device->GetAllocator(), &createInfo, &allocCreateInfo,
             &this->image, &this->allocation, nullptr),
             "Failed to create image.");
         DebugNames::Set(*device, VK_OBJECT_TYPE_IMAGE, reinterpret_cast<uint64_t>(this->image),
@@ -92,7 +92,7 @@ namespace Vk
         viewInfo.subresourceRange.baseArrayLayer = 0;
         viewInfo.subresourceRange.layerCount = arrayLayers;
 
-        BX_ASSERT(!vkCreateImageView(device->GetDevice(), &viewInfo, nullptr, &this->imageView),
+        VK_ASSERT(!vkCreateImageView(device->GetDevice(), &viewInfo, nullptr, &this->imageView),
             "Failed to create image view");
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
@@ -1,0 +1,130 @@
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image_format.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
+
+namespace Vk
+{
+    uint32_t Image::Width() const {
+        return this->width;
+    }
+
+    uint32_t Image::Height() const {
+        return this->height;
+    }
+
+    uint32_t Image::Depth() const {
+        return this->depth;
+    }
+
+    uint32_t Image::Mips() const {
+        return this->mips;
+    }
+
+    uint32_t Image::ArrayLayers() const {
+        return this->arrayLayers;
+    }
+
+    VkFormat Image::Format() const {
+        return this->format;
+    }
+
+    Image::Image(const String& name, std::shared_ptr<Device> device,
+        const PhysicalDevice& physicalDevice, uint32_t width, uint32_t height,
+        uint32_t mips, VkImageUsageFlags usage, VkFormat format, uint32_t arrayLayers,
+        VkImageType dims, unsigned depth)
+        : device(device),
+        imageView(VK_NULL_HANDLE),
+        width(width),
+        height(height),
+        depth(depth),
+        mips(mips),
+        arrayLayers(arrayLayers),
+        format(format) {
+        VkImageCreateInfo createInfo{};
+        createInfo.sType = VkStructureType::VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        createInfo.imageType = dims;
+        createInfo.extent.width = width;
+        createInfo.extent.height = height;
+        createInfo.extent.depth = depth;
+        createInfo.mipLevels = mips;
+        createInfo.format = format;
+        createInfo.tiling = VkImageTiling::VK_IMAGE_TILING_OPTIMAL;
+        createInfo.arrayLayers = arrayLayers;
+        createInfo.usage = usage;
+        createInfo.initialLayout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
+        createInfo.samples = VkSampleCountFlagBits::VK_SAMPLE_COUNT_1_BIT;
+        if (arrayLayers > 1)
+            createInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+
+        VmaAllocationCreateInfo allocCreateInfo{};
+        allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+        BX_ASSERT(!vmaCreateImage(device->GetAllocator(), &createInfo, &allocCreateInfo,
+            &this->image, &this->allocation, nullptr),
+            "Failed to create image.");
+        DebugNames::Set(*device, VK_OBJECT_TYPE_IMAGE, reinterpret_cast<uint64_t>(this->image),
+            name);
+
+        ImageState imageState;
+        imageState.layout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
+        imageState.stageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        imageState.accessFlags = VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;//VkAccessFlagBits::VK_ACCESS_NONE;//
+        ResourceStateTracker::AddGlobalImageState(this->image, imageState);
+
+        VkImageViewCreateInfo viewInfo{};
+        viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewInfo.image = this->image;
+        viewInfo.viewType = (arrayLayers == 1)
+            ? ((dims == VK_IMAGE_TYPE_2D) ? VK_IMAGE_VIEW_TYPE_2D
+                : VK_IMAGE_VIEW_TYPE_3D)
+            : VK_IMAGE_VIEW_TYPE_CUBE;
+        viewInfo.format = format;
+        viewInfo.subresourceRange.aspectMask =
+            IsDepthFormat(format) ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
+        viewInfo.subresourceRange.baseMipLevel = 0;
+        viewInfo.subresourceRange.levelCount = mips;
+        viewInfo.subresourceRange.baseArrayLayer = 0;
+        viewInfo.subresourceRange.layerCount = arrayLayers;
+
+        BX_ASSERT(!vkCreateImageView(device->GetDevice(), &viewInfo, nullptr, &this->imageView),
+            "Failed to create image view");
+    }
+
+    Image::Image(const String& name, std::shared_ptr<Device> device, VkImage image, VkImageView imageView,
+        uint32_t width, uint32_t height)
+        : device(device),
+        image(image),
+        imageView(imageView),
+        allocation(VK_NULL_HANDLE),
+        width(width),
+        height(height),
+        depth(1),
+        mips(1),
+        arrayLayers(1) {
+        DebugNames::Set(*device, VK_OBJECT_TYPE_IMAGE, reinterpret_cast<uint64_t>(this->image),
+            name);
+    }
+
+    Image::~Image() {
+        vkDestroyImageView(this->device->GetDevice(), this->imageView, nullptr);
+
+        if (this->allocation) {
+            ResourceStateTracker::RemoveGlobalImageState(this->image);
+            vmaDestroyImage(this->device->GetAllocator(), this->image, this->allocation);
+        }
+    }
+
+    VkImage Image::GetImage() const {
+        return this->image;
+    }
+
+    VkImageView Image::GetImageView() const {
+        return this->imageView;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
@@ -75,7 +75,7 @@ namespace Vk
         ImageState imageState;
         imageState.layout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
         imageState.stageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-        imageState.accessFlags = VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;//VkAccessFlagBits::VK_ACCESS_NONE;//
+        imageState.accessFlags = VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;
         ResourceStateTracker::AddGlobalImageState(this->image, imageState);
 
         VkImageViewCreateInfo viewInfo{};

--- a/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
@@ -73,9 +73,9 @@ namespace Vk
             name);
 
         ImageState imageState;
-        imageState.layout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
-        imageState.stageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-        imageState.accessFlags = VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;
+        imageState.currentLayout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
+        imageState.lastStageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        //imageState.accessFlags = VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;
         ResourceStateTracker::AddGlobalImageState(this->image, imageState);
 
         VkImageViewCreateInfo viewInfo{};

--- a/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/image.cpp
@@ -45,7 +45,8 @@ namespace Vk
         depth(depth),
         mips(mips),
         arrayLayers(arrayLayers),
-        format(format) {
+        format(format)
+    {
         VkImageCreateInfo createInfo{};
         createInfo.sType = VkStructureType::VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
         createInfo.imageType = dims;

--- a/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
@@ -45,7 +45,7 @@ namespace Vk
         }
 
         VkInstance instance;
-        BX_ASSERT(!vkCreateInstance(&createInfo, nullptr, &instance), "Failed to create instance.");
+        VK_ASSERT(!vkCreateInstance(&createInfo, nullptr, &instance), "Failed to create instance.");
         return instance;
     }
 
@@ -88,7 +88,7 @@ namespace Vk
         createInfo.hinstance = GetModuleHandle(nullptr);
 
         VkSurfaceKHR surface;
-        BX_ASSERT(!vkCreateWin32SurfaceKHR(instance, &createInfo, nullptr, &surface),
+        VK_ASSERT(!vkCreateWin32SurfaceKHR(instance, &createInfo, nullptr, &surface),
             "Failed to create surface.");
         return surface;
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
@@ -64,10 +64,15 @@ namespace Vk
             Pfn::vkCreateDebugReportCallbackEXT(this->instance, &createInfo, nullptr,
                 &this->debugReportCallback);
         }
+        else
+        {
+            this->debugReportCallback = VK_NULL_HANDLE;
+        }
     }
 
     Instance::~Instance() {
-        Pfn::vkDestroyDebugReportCallbackEXT(this->instance, this->debugReportCallback, nullptr);
+        if (this->debugReportCallback)
+            Pfn::vkDestroyDebugReportCallbackEXT(this->instance, this->debugReportCallback, nullptr);
         vkDestroySurfaceKHR(this->instance, this->surface, nullptr);
         vkDestroyInstance(this->instance, nullptr);
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
@@ -1,0 +1,98 @@
+#include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/extensions.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/pfn.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+#ifdef BX_WINDOW_GLFW_BACKEND
+#define GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#include "bx/engine/modules/window/backend/window_glfw.hpp"
+#endif
+
+namespace Vk
+{
+    VkInstance CreateInstance(bool debug) {
+        VkApplicationInfo appInfo{};
+        appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+        appInfo.pApplicationName = "BX App";
+        appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+        appInfo.pEngineName = "BX";
+        appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+        appInfo.apiVersion = VULKAN_VERSION;
+
+        std::vector<const char*> extensions = PlatformInstanceExtensions();
+        for (size_t i = 0; i < instanceExtensions.size(); i++) {
+            extensions.push_back(instanceExtensions[i]);
+        }
+
+        VkInstanceCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        createInfo.pApplicationInfo = &appInfo;
+        createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
+        createInfo.ppEnabledExtensionNames = extensions.data();
+
+        if (debug) {
+            CheckValidationLayerSupport();
+            createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());
+            createInfo.ppEnabledLayerNames = validationLayers.data();
+        }
+        else {
+            createInfo.enabledLayerCount = 0;
+        }
+
+        VkInstance instance;
+        BX_ASSERT(!vkCreateInstance(&createInfo, nullptr, &instance), "Failed to create instance.");
+        return instance;
+    }
+
+    Instance::Instance(void* window, bool debug) {
+        this->instance = CreateInstance(debug);
+        this->surface = CreateSurface(window, this->instance);
+
+        Pfn::Load(this->instance);
+
+        if (debug) {
+            VkDebugReportCallbackCreateInfoEXT createInfo{};
+            createInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
+            createInfo.pfnCallback = VulkanDebugCallback;
+            createInfo.flags = VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+            Pfn::vkCreateDebugReportCallbackEXT(this->instance, &createInfo, nullptr,
+                &this->debugReportCallback);
+        }
+    }
+
+    Instance::~Instance() {
+        Pfn::vkDestroyDebugReportCallbackEXT(this->instance, this->debugReportCallback, nullptr);
+        vkDestroySurfaceKHR(this->instance, this->surface, nullptr);
+        vkDestroyInstance(this->instance, nullptr);
+    }
+
+    VkInstance Instance::GetInstance() const {
+        return this->instance;
+    }
+
+    VkSurfaceKHR Instance::GetSurface() const {
+        return this->surface;
+    }
+
+#ifdef BX_PLATFORM_PC
+    VkSurfaceKHR Instance::CreateSurface(void* window, VkInstance instance) {
+        VkWin32SurfaceCreateInfoKHR createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+        createInfo.hwnd = glfwGetWin32Window(reinterpret_cast<GLFWwindow*>(window));
+        createInfo.hinstance = GetModuleHandle(nullptr);
+
+        VkSurfaceKHR surface;
+        BX_ASSERT(!vkCreateWin32SurfaceKHR(instance, &createInfo, nullptr, &surface),
+            "Failed to create surface.");
+        return surface;
+    }
+#elif defined BX_PLATFORM_LINUX
+    // TODO
+#endif
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/pfn.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/pfn.cpp
@@ -1,0 +1,54 @@
+#include "bx/engine/modules/graphics/backend/vulkan/pfn.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+namespace Vk
+{
+    PFN_vkGetBufferDeviceAddress Pfn::vkGetBufferDeviceAddress = VK_NULL_HANDLE;
+
+    PFN_vkSetDebugUtilsObjectNameEXT Pfn::vkSetDebugUtilsObjectNameEXT = VK_NULL_HANDLE;
+    PFN_vkCreateDebugReportCallbackEXT Pfn::vkCreateDebugReportCallbackEXT = VK_NULL_HANDLE;
+    PFN_vkDestroyDebugReportCallbackEXT Pfn::vkDestroyDebugReportCallbackEXT = VK_NULL_HANDLE;
+
+    PFN_vkCreateAccelerationStructureKHR Pfn::vkCreateAccelerationStructureKHR = VK_NULL_HANDLE;
+    PFN_vkDestroyAccelerationStructureKHR Pfn::vkDestroyAccelerationStructureKHR = VK_NULL_HANDLE;
+    PFN_vkGetAccelerationStructureBuildSizesKHR Pfn::vkGetAccelerationStructureBuildSizesKHR =
+        VK_NULL_HANDLE;
+    PFN_vkCmdBuildAccelerationStructuresKHR Pfn::vkCmdBuildAccelerationStructuresKHR =
+        VK_NULL_HANDLE;
+
+    void Pfn::Load(VkInstance instance) {
+        Pfn::vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)vkGetInstanceProcAddr(
+            instance, "vkGetBufferDeviceAddress");
+        BX_ENSURE(Pfn::vkGetBufferDeviceAddress);
+
+        Pfn::vkSetDebugUtilsObjectNameEXT = (PFN_vkSetDebugUtilsObjectNameEXT)vkGetInstanceProcAddr(
+            instance, "vkSetDebugUtilsObjectNameEXT");
+        Pfn::vkCreateDebugReportCallbackEXT =
+            (PFN_vkCreateDebugReportCallbackEXT)vkGetInstanceProcAddr(
+                instance, "vkCreateDebugReportCallbackEXT");
+        Pfn::vkDestroyDebugReportCallbackEXT =
+            (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(
+                instance, "vkDestroyDebugReportCallbackEXT");
+        BX_ENSURE(Pfn::vkSetDebugUtilsObjectNameEXT);
+        BX_ENSURE(Pfn::vkCreateDebugReportCallbackEXT);
+        BX_ENSURE(Pfn::vkDestroyDebugReportCallbackEXT);
+
+        Pfn::vkCreateAccelerationStructureKHR =
+            (PFN_vkCreateAccelerationStructureKHR)vkGetInstanceProcAddr(
+                instance, "vkCreateAccelerationStructureKHR");
+        Pfn::vkDestroyAccelerationStructureKHR =
+            (PFN_vkDestroyAccelerationStructureKHR)vkGetInstanceProcAddr(
+                instance, "vkDestroyAccelerationStructureKHR");
+        Pfn::vkGetAccelerationStructureBuildSizesKHR =
+            (PFN_vkGetAccelerationStructureBuildSizesKHR)vkGetInstanceProcAddr(
+                instance, "vkGetAccelerationStructureBuildSizesKHR");
+        Pfn::vkCmdBuildAccelerationStructuresKHR =
+            (PFN_vkCmdBuildAccelerationStructuresKHR)vkGetInstanceProcAddr(
+                instance, "vkCmdBuildAccelerationStructuresKHR");
+        BX_ENSURE(Pfn::vkCreateAccelerationStructureKHR);
+        BX_ENSURE(Pfn::vkDestroyAccelerationStructureKHR);
+        BX_ENSURE(Pfn::vkGetAccelerationStructureBuildSizesKHR);
+        BX_ENSURE(Pfn::vkCmdBuildAccelerationStructuresKHR);
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/pfn.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/pfn.cpp
@@ -2,6 +2,8 @@
 
 #include "bx/engine/core/macros.hpp"
 
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
 namespace Vk
 {
     PFN_vkGetBufferDeviceAddress Pfn::vkGetBufferDeviceAddress = VK_NULL_HANDLE;
@@ -20,7 +22,7 @@ namespace Vk
     void Pfn::Load(VkInstance instance) {
         Pfn::vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)vkGetInstanceProcAddr(
             instance, "vkGetBufferDeviceAddress");
-        BX_ENSURE(Pfn::vkGetBufferDeviceAddress);
+        VK_ENSURE(Pfn::vkGetBufferDeviceAddress);
 
         Pfn::vkSetDebugUtilsObjectNameEXT = (PFN_vkSetDebugUtilsObjectNameEXT)vkGetInstanceProcAddr(
             instance, "vkSetDebugUtilsObjectNameEXT");
@@ -30,9 +32,9 @@ namespace Vk
         Pfn::vkDestroyDebugReportCallbackEXT =
             (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(
                 instance, "vkDestroyDebugReportCallbackEXT");
-        BX_ENSURE(Pfn::vkSetDebugUtilsObjectNameEXT);
-        BX_ENSURE(Pfn::vkCreateDebugReportCallbackEXT);
-        BX_ENSURE(Pfn::vkDestroyDebugReportCallbackEXT);
+        VK_ENSURE(Pfn::vkSetDebugUtilsObjectNameEXT);
+        VK_ENSURE(Pfn::vkCreateDebugReportCallbackEXT);
+        VK_ENSURE(Pfn::vkDestroyDebugReportCallbackEXT);
 
         Pfn::vkCreateAccelerationStructureKHR =
             (PFN_vkCreateAccelerationStructureKHR)vkGetInstanceProcAddr(
@@ -46,9 +48,9 @@ namespace Vk
         Pfn::vkCmdBuildAccelerationStructuresKHR =
             (PFN_vkCmdBuildAccelerationStructuresKHR)vkGetInstanceProcAddr(
                 instance, "vkCmdBuildAccelerationStructuresKHR");
-        BX_ENSURE(Pfn::vkCreateAccelerationStructureKHR);
-        BX_ENSURE(Pfn::vkDestroyAccelerationStructureKHR);
-        BX_ENSURE(Pfn::vkGetAccelerationStructureBuildSizesKHR);
-        BX_ENSURE(Pfn::vkCmdBuildAccelerationStructuresKHR);
+        VK_ENSURE(Pfn::vkCreateAccelerationStructureKHR);
+        VK_ENSURE(Pfn::vkDestroyAccelerationStructureKHR);
+        VK_ENSURE(Pfn::vkGetAccelerationStructureBuildSizesKHR);
+        VK_ENSURE(Pfn::vkCmdBuildAccelerationStructuresKHR);
     }
 }

--- a/src/bx/engine/modules/graphics/backend/vulkan/physical_device.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/physical_device.cpp
@@ -1,0 +1,157 @@
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/extensions.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
+
+namespace Vk
+{
+    bool IsDeviceSuitable(VkPhysicalDevice device) {
+        VkPhysicalDeviceProperties deviceProperties;
+        VkPhysicalDeviceFeatures deviceFeatures;
+        vkGetPhysicalDeviceProperties(device, &deviceProperties);
+        vkGetPhysicalDeviceFeatures(device, &deviceFeatures);
+
+        bool extensionsSupported = CheckDeviceExtensionSupport(device);
+
+        return  // deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU &&
+            extensionsSupported;
+    }
+
+    std::pair<VkPhysicalDevice, bool> PickPhysicalDevice(VkInstance instance,
+        VkSurfaceKHR surface) {
+        VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+
+        uint32_t deviceCount = 0;
+        vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+        BX_ASSERT(deviceCount > 0, "No vulkan compatible device found.");
+
+        std::vector<VkPhysicalDevice> devices(deviceCount);
+        vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
+
+        VkPhysicalDevice fallbackPhysicalDevice = VK_NULL_HANDLE;
+        bool raytracingSuitable = true;
+        for (auto& device : devices) {
+            if (IsDeviceSuitable(device)) {
+                if (CheckDeviceRaytracingExtensionSupport(device)) {
+                    physicalDevice = device;
+                    break;
+                }
+                else {
+                    fallbackPhysicalDevice = device;
+                }
+            }
+        }
+        if (physicalDevice == VK_NULL_HANDLE) {
+            raytracingSuitable = false;
+            physicalDevice = fallbackPhysicalDevice;
+        }
+
+        BX_ASSERT(physicalDevice != VK_NULL_HANDLE, "No vulkan compatible device found.");
+
+        VkPhysicalDeviceProperties deviceProperties;
+        vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
+        BX_LOGI("Using Device: {}", deviceProperties.deviceName);
+
+        return std::make_pair(physicalDevice, raytracingSuitable);
+    }
+
+    PhysicalDevice::PhysicalDevice(const Instance& instance) {
+        auto pickedDevice = PickPhysicalDevice(instance.GetInstance(), instance.GetSurface());
+        this->physicalDevice = pickedDevice.first;
+        this->rayTracingSuitable = pickedDevice.second;
+
+        if (this->rayTracingSuitable) {
+            VkPhysicalDeviceAccelerationStructurePropertiesKHR accelProperties{};
+            VkPhysicalDeviceRayTracingPipelinePropertiesKHR pipelineProperties{};
+            accelProperties.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
+            pipelineProperties.sType =
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
+            pipelineProperties.pNext = &accelProperties;
+
+            VkPhysicalDeviceProperties2 props = {};
+            props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+            props.pNext = &pipelineProperties;
+            vkGetPhysicalDeviceProperties2(this->physicalDevice, &props);
+            this->rayTracingProperties = RTProperties{ accelProperties, pipelineProperties };
+        }
+        else {
+            this->rayTracingProperties = RTProperties{};
+        }
+
+        uint32_t queueFamilyCount = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(this->physicalDevice, &queueFamilyCount, nullptr);
+        std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+        vkGetPhysicalDeviceQueueFamilyProperties(this->physicalDevice, &queueFamilyCount,
+            queueFamilies.data());
+
+        this->graphicsFamily = UINT_MAX;
+        this->computeFamily = UINT_MAX;
+        this->presentFamily = UINT_MAX;
+        for (size_t i = 0; i < queueFamilyCount; i++) {
+            if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+                this->graphicsFamily = static_cast<uint32_t>(i);
+            }
+
+            if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
+                this->computeFamily = static_cast<uint32_t>(i);
+            }
+
+            VkBool32 presentSupport = false;
+            vkGetPhysicalDeviceSurfaceSupportKHR(this->physicalDevice, static_cast<uint32_t>(i),
+                instance.GetSurface(), &presentSupport);
+            if (presentSupport) {
+                this->presentFamily = static_cast<uint32_t>(i);
+            }
+
+            if (this->graphicsFamily != UINT_MAX && this->computeFamily != UINT_MAX &&
+                this->presentFamily != UINT_MAX) {
+                return;
+            }
+        }
+
+        BX_LOGE("Missing queue families!");
+    }
+
+    VkPhysicalDevice PhysicalDevice::GetPhysicalDevice() const {
+        return this->physicalDevice;
+    }
+
+    bool PhysicalDevice::RayTracingSuitable() const {
+        return this->rayTracingSuitable;
+    }
+
+    const RTProperties& PhysicalDevice::RayTracingProperties() const {
+        return this->rayTracingProperties;
+    }
+
+    uint32_t PhysicalDevice::GraphicsFamily() const {
+        return this->graphicsFamily;
+    }
+
+    uint32_t PhysicalDevice::ComputeFamily() const {
+        return this->computeFamily;
+    }
+
+    uint32_t PhysicalDevice::PresentFamily() const {
+        return this->presentFamily;
+    }
+
+    uint32_t PhysicalDevice::FindMemoryType(uint32_t typeFilter,
+        VkMemoryPropertyFlags properties) const {
+        VkPhysicalDeviceMemoryProperties memProperties;
+        vkGetPhysicalDeviceMemoryProperties(this->physicalDevice, &memProperties);
+
+        for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++) {
+            if ((typeFilter & (1 << i)) &&
+                (memProperties.memoryTypes[i].propertyFlags & properties) == properties) {
+                return i;
+            }
+        }
+
+        BX_LOGE("Failed to find suitable memory type.");
+        return 0;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/physical_device.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/physical_device.cpp
@@ -4,6 +4,7 @@
 
 #include "bx/engine/modules/graphics/backend/vulkan/extensions.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
 
 namespace Vk
 {
@@ -25,7 +26,7 @@ namespace Vk
 
         uint32_t deviceCount = 0;
         vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
-        BX_ASSERT(deviceCount > 0, "No vulkan compatible device found.");
+        VK_ASSERT(deviceCount > 0, "No vulkan compatible device found.");
 
         std::vector<VkPhysicalDevice> devices(deviceCount);
         vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
@@ -48,7 +49,7 @@ namespace Vk
             physicalDevice = fallbackPhysicalDevice;
         }
 
-        BX_ASSERT(physicalDevice != VK_NULL_HANDLE, "No vulkan compatible device found.");
+        VK_ASSERT(physicalDevice != VK_NULL_HANDLE, "No vulkan compatible device found.");
 
         VkPhysicalDeviceProperties deviceProperties;
         vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);

--- a/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
@@ -1,0 +1,95 @@
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    RenderPass::RenderPass(const String& name, std::shared_ptr<Device> device,
+        const List<VkFormat>& colorFormats,
+        const Optional<VkFormat>& depthFormat)
+        : device(device) {
+        List<VkAttachmentDescription> attachements;
+
+        List<VkAttachmentReference> colorAttachmentRefs;
+        for (size_t i = 0; i < colorFormats.size(); i++) {
+            VkAttachmentDescription colorAttachment{};
+            colorAttachment.format = colorFormats[i];
+            colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+            colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+            colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            colorAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+            VkAttachmentReference colorAttachmentRef{};
+            colorAttachmentRef.attachment = static_cast<uint32_t>(i);
+            colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+            attachements.push_back(colorAttachment);
+            colorAttachmentRefs.push_back(colorAttachmentRef);
+        }
+
+        VkAttachmentReference depthAttachmentRef{};
+        depthAttachmentRef.attachment = static_cast<uint32_t>(colorAttachmentRefs.size());
+        depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+        if (depthFormat.IsSome()) {
+            VkAttachmentDescription depthAttachment{};
+            depthAttachment.format = depthFormat.Unwrap();
+            depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+            depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+            depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+            depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+            attachements.push_back(depthAttachment);
+        }
+
+        VkSubpassDescription subpass{};
+        subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass.colorAttachmentCount = static_cast<uint32_t>(colorAttachmentRefs.size());
+        subpass.pColorAttachments = colorAttachmentRefs.data();
+        subpass.pDepthStencilAttachment = depthFormat.IsSome() ? &depthAttachmentRef : nullptr;
+
+        VkSubpassDependency dependency{};
+        dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        dependency.dstSubpass = 0;
+        dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+        dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+        dependency.srcAccessMask =
+            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        dependency.dstAccessMask =
+            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+        VkRenderPassCreateInfo renderPassInfo{};
+        renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+        renderPassInfo.attachmentCount = static_cast<uint32_t>(attachements.size());
+        renderPassInfo.pAttachments = attachements.data();
+        renderPassInfo.subpassCount = 1;
+        renderPassInfo.pSubpasses = &subpass;
+        renderPassInfo.dependencyCount = 1;
+        renderPassInfo.pDependencies = &dependency;
+
+        BX_ASSERT(
+            !vkCreateRenderPass(device->GetDevice(), &renderPassInfo, nullptr, &this->renderPass),
+            "Failed to create render pass.");
+        
+        DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_RENDER_PASS,
+            reinterpret_cast<uint64_t>(this->renderPass), name);
+    }
+
+    RenderPass::~RenderPass() {
+        vkDestroyRenderPass(this->device->GetDevice(), this->renderPass, nullptr);
+    }
+
+    VkRenderPass RenderPass::GetRenderPass() const {
+        return this->renderPass;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
@@ -18,11 +18,11 @@ namespace Vk
             VkAttachmentDescription colorAttachment{};
             colorAttachment.format = info.colorFormats[i];
             colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-            colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            colorAttachment.loadOp = info.clear ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
             colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
             colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-            colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            colorAttachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
             colorAttachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
             VkAttachmentReference colorAttachmentRef{};
@@ -41,11 +41,11 @@ namespace Vk
             VkAttachmentDescription depthAttachment{};
             depthAttachment.format = info.depthFormat.Unwrap();
             depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-            depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            depthAttachment.loadOp = info.clear ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
             depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
             depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
             depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-            depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            depthAttachment.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
             depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
             attachements.push_back(depthAttachment);
         }

--- a/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
@@ -8,15 +8,14 @@
 namespace Vk
 {
     RenderPass::RenderPass(const String& name, std::shared_ptr<Device> device,
-        const List<VkFormat>& colorFormats,
-        const Optional<VkFormat>& depthFormat)
+        const RenderPassInfo& info)
         : device(device) {
         List<VkAttachmentDescription> attachements;
 
         List<VkAttachmentReference> colorAttachmentRefs;
-        for (size_t i = 0; i < colorFormats.size(); i++) {
+        for (size_t i = 0; i < info.colorFormats.size(); i++) {
             VkAttachmentDescription colorAttachment{};
-            colorAttachment.format = colorFormats[i];
+            colorAttachment.format = info.colorFormats[i];
             colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
             colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
             colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -37,9 +36,9 @@ namespace Vk
         depthAttachmentRef.attachment = static_cast<uint32_t>(colorAttachmentRefs.size());
         depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-        if (depthFormat.IsSome()) {
+        if (info.depthFormat.IsSome()) {
             VkAttachmentDescription depthAttachment{};
-            depthAttachment.format = depthFormat.Unwrap();
+            depthAttachment.format = info.depthFormat.Unwrap();
             depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
             depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
             depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -54,7 +53,7 @@ namespace Vk
         subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
         subpass.colorAttachmentCount = static_cast<uint32_t>(colorAttachmentRefs.size());
         subpass.pColorAttachments = colorAttachmentRefs.data();
-        subpass.pDepthStencilAttachment = depthFormat.IsSome() ? &depthAttachmentRef : nullptr;
+        subpass.pDepthStencilAttachment = info.depthFormat.IsSome() ? &depthAttachmentRef : nullptr;
 
         VkSubpassDependency dependency{};
         dependency.srcSubpass = VK_SUBPASS_EXTERNAL;

--- a/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
@@ -5,6 +5,7 @@
 #include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image_format.hpp"
 
 namespace Vk
 {
@@ -35,9 +36,13 @@ namespace Vk
 
         VkAttachmentReference depthAttachmentRef{};
         depthAttachmentRef.attachment = static_cast<uint32_t>(colorAttachmentRefs.size());
-        depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL; // TODO: cover non-stencil formats
+        depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
         if (info.depthFormat.IsSome()) {
+            VkImageLayout depthStencilLayout = GetDepthStencilLayout(info.depthFormat.Unwrap());
+            
+            depthAttachmentRef.layout = depthStencilLayout;
+
             VkAttachmentDescription depthAttachment{};
             depthAttachment.format = info.depthFormat.Unwrap();
             depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -45,8 +50,8 @@ namespace Vk
             depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
             depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
             depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-            depthAttachment.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-            depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+            depthAttachment.initialLayout = depthStencilLayout;
+            depthAttachment.finalLayout = depthStencilLayout;
             attachements.push_back(depthAttachment);
         }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
@@ -3,6 +3,7 @@
 #include "bx/engine/core/macros.hpp"
 
 #include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
 
 namespace Vk
@@ -22,7 +23,7 @@ namespace Vk
             colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
             colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            colorAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+            colorAttachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
             VkAttachmentReference colorAttachmentRef{};
             colorAttachmentRef.attachment = static_cast<uint32_t>(i);
@@ -34,7 +35,7 @@ namespace Vk
 
         VkAttachmentReference depthAttachmentRef{};
         depthAttachmentRef.attachment = static_cast<uint32_t>(colorAttachmentRefs.size());
-        depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL; // TODO: cover non-stencil formats
 
         if (info.depthFormat.IsSome()) {
             VkAttachmentDescription depthAttachment{};

--- a/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/render_pass.cpp
@@ -77,7 +77,7 @@ namespace Vk
         renderPassInfo.dependencyCount = 1;
         renderPassInfo.pDependencies = &dependency;
 
-        BX_ASSERT(
+        VK_ASSERT(
             !vkCreateRenderPass(device->GetDevice(), &renderPassInfo, nullptr, &this->renderPass),
             "Failed to create render pass.");
         

--- a/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
@@ -1,0 +1,54 @@
+#include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image_format.hpp"
+
+namespace Vk
+{
+    HashMap<VkImage, ImageState> ResourceStateTracker::globalImageStates{};
+
+    void ResourceStateTracker::TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
+        ImageState newState) {
+        const ImageState& oldState = globalImageStates.find(image.GetImage())->second;
+
+        VkImageMemoryBarrier barrier{};
+        barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.oldLayout = oldState.layout;
+        barrier.newLayout = newState.layout;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.srcAccessMask = oldState.accessFlags;
+        barrier.dstAccessMask = newState.accessFlags;
+        barrier.image = image.GetImage();
+        if (IsDepthFormat(image.Format()))
+            barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+        else
+            barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        barrier.subresourceRange.baseMipLevel = 0;
+        barrier.subresourceRange.levelCount = image.Mips();
+        barrier.subresourceRange.baseArrayLayer = 0;
+        barrier.subresourceRange.layerCount = image.ArrayLayers();
+
+        VkPipelineStageFlags sourceStage = oldState.stageFlags;
+        VkPipelineStageFlags destinationStage = newState.stageFlags;
+
+        vkCmdPipelineBarrier(cmdBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1,
+            &barrier);
+
+        // TODO: just copied this code from DLR, but it looks like it's broken?
+        // Shouldn't it write out the new state to the global states?
+    }
+
+    void ResourceStateTracker::AddGlobalImageState(VkImage image, ImageState state) {
+        if (globalImageStates.find(image) == globalImageStates.end())
+            globalImageStates.insert(std::make_pair(image, state));
+        else
+            BX_LOGW("Adding image state to tracker twice.");
+    }
+
+    void ResourceStateTracker::RemoveGlobalImageState(VkImage image) {
+        globalImageStates.erase(image);
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
@@ -9,21 +9,46 @@ namespace Vk
 {
     HashMap<VkImage, ImageState> ResourceStateTracker::globalImageStates{};
 
-    void ResourceStateTracker::TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
-        ImageState newState) {
-        ImageState& oldState = globalImageStates.find(image.GetImage())->second;
+    VkAccessFlags LayoutToAccessFlags(VkImageLayout layout)
+    {
+        switch (layout)
+        {
+        case VK_IMAGE_LAYOUT_UNDEFINED:
+            return VK_ACCESS_NONE;
 
-        if (oldState == newState)
+        case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+            return VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+        case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+            return VK_ACCESS_SHADER_READ_BIT;
+        case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
+            return VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+        case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+            return VK_ACCESS_TRANSFER_READ_BIT;
+        case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+            return VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        default:
+            BX_FAIL("Unsupported image layout");
+            return VK_ACCESS_NONE;
+        }
+    }
+
+    void ResourceStateTracker::TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
+        VkImageLayout newLayout, VkPipelineStageFlags newStage) {
+        ImageState& state = globalImageStates.find(image.GetImage())->second;
+
+        if (state.currentLayout == newLayout)
             return;
 
         VkImageMemoryBarrier barrier{};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-        barrier.oldLayout = oldState.layout;
-        barrier.newLayout = newState.layout;
+        barrier.oldLayout = state.currentLayout;
+        barrier.newLayout = newLayout;
+        barrier.srcAccessMask = LayoutToAccessFlags(state.currentLayout);
+        barrier.dstAccessMask = LayoutToAccessFlags(newLayout);
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        barrier.srcAccessMask = oldState.accessFlags;
-        barrier.dstAccessMask = newState.accessFlags;
         barrier.image = image.GetImage();
         if (IsDepthFormat(image.Format()))
             barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
@@ -34,13 +59,14 @@ namespace Vk
         barrier.subresourceRange.baseArrayLayer = 0;
         barrier.subresourceRange.layerCount = image.ArrayLayers();
 
-        VkPipelineStageFlags sourceStage = oldState.stageFlags;
-        VkPipelineStageFlags destinationStage = newState.stageFlags;
+        VkPipelineStageFlags sourceStage = state.lastStageFlags;
+        VkPipelineStageFlags destinationStage = newStage;
 
         vkCmdPipelineBarrier(cmdBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1,
             &barrier);
 
-        oldState = newState;
+        state.currentLayout = newLayout;
+        state.lastStageFlags = newStage;
     }
 
     void ResourceStateTracker::AddGlobalImageState(VkImage image, ImageState state) {

--- a/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
@@ -11,7 +11,10 @@ namespace Vk
 
     void ResourceStateTracker::TransitionImage(VkCommandBuffer cmdBuffer, const Image& image,
         ImageState newState) {
-        const ImageState& oldState = globalImageStates.find(image.GetImage())->second;
+        ImageState& oldState = globalImageStates.find(image.GetImage())->second;
+
+        if (oldState == newState)
+            return;
 
         VkImageMemoryBarrier barrier{};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -37,8 +40,7 @@ namespace Vk
         vkCmdPipelineBarrier(cmdBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1,
             &barrier);
 
-        // TODO: just copied this code from DLR, but it looks like it's broken?
-        // Shouldn't it write out the new state to the global states?
+        oldState = newState;
     }
 
     void ResourceStateTracker::AddGlobalImageState(VkImage image, ImageState state) {

--- a/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
@@ -29,7 +29,7 @@ namespace Vk
             return VK_ACCESS_SHADER_READ_BIT;
 
         case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
-            return VK_ACCESS_TRANSFER_READ_BIT;
+            return VK_ACCESS_TRANSFER_READ_BIT;// | VK_ACCESS_HOST_READ_BIT;
         case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
             return VK_ACCESS_TRANSFER_WRITE_BIT;
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.cpp
@@ -11,17 +11,22 @@ namespace Vk
 
     VkAccessFlags LayoutToAccessFlags(VkImageLayout layout)
     {
+        //return VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
         switch (layout)
         {
         case VK_IMAGE_LAYOUT_UNDEFINED:
             return VK_ACCESS_NONE;
+        case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
+            return VK_ACCESS_NONE;// VK_ACCESS_NONE;
 
         case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-            return VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+            return VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;// | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        case VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL:
+            return VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+            return VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;;
         case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
             return VK_ACCESS_SHADER_READ_BIT;
-        case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
-            return VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
         case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
             return VK_ACCESS_TRANSFER_READ_BIT;
@@ -50,8 +55,14 @@ namespace Vk
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         barrier.image = image.GetImage();
-        if (IsDepthFormat(image.Format()))
-            barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
+        if (IsDepthFormat(image.Format()) || IsStencilFormat(image.Format()))
+        {
+            if (IsDepthFormat(image.Format()))
+                barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+            if (IsStencilFormat(image.Format()))
+                barrier.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+        }
         else
             barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         barrier.subresourceRange.baseMipLevel = 0;
@@ -67,6 +78,18 @@ namespace Vk
 
         state.currentLayout = newLayout;
         state.lastStageFlags = newStage;
+    }
+
+    VkImageLayout ResourceStateTracker::GetCurrentImageLayout(const Image& image)
+    {
+        ImageState& state = globalImageStates.find(image.GetImage())->second;
+        return state.currentLayout;
+    }
+
+    void ResourceStateTracker::ApplyImplicitImageTransition(const Image& image, VkImageLayout newLayout)
+    {
+        ImageState& state = globalImageStates.find(image.GetImage())->second;
+        state.currentLayout = newLayout;
     }
 
     void ResourceStateTracker::AddGlobalImageState(VkImage image, ImageState state) {

--- a/src/bx/engine/modules/graphics/backend/vulkan/sampler.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/sampler.cpp
@@ -1,0 +1,48 @@
+#include "bx/engine/modules/graphics/backend/vulkan/sampler.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    Sampler::Sampler(const String& name, std::shared_ptr<Device> device,
+        const PhysicalDevice& physicalDevice, const SamplerInfo& info)
+        : device(device) {
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physicalDevice.GetPhysicalDevice(), &properties);
+
+        VkSamplerCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        createInfo.magFilter = info.filterMode;
+        createInfo.minFilter = info.filterMode;
+        createInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        createInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        createInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        createInfo.anisotropyEnable = VK_TRUE;
+        createInfo.maxAnisotropy = properties.limits.maxSamplerAnisotropy;
+        createInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        createInfo.unnormalizedCoordinates = VK_FALSE;
+        createInfo.compareEnable = VK_FALSE;
+        createInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+        createInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        createInfo.mipLodBias = 0.0f;
+        createInfo.minLod = 0.0f;
+        createInfo.maxLod = 16.0f;
+
+        BX_ASSERT(!vkCreateSampler(device->GetDevice(), &createInfo, nullptr, &this->sampler),
+            "Failed to create sampler.");
+        DebugNames::Set(*device, VK_OBJECT_TYPE_SAMPLER,
+            reinterpret_cast<uint64_t>(this->sampler), name);
+    }
+
+    Sampler::~Sampler() {
+        vkDestroySampler(this->device->GetDevice(), this->sampler, nullptr);
+    }
+
+    VkSampler Sampler::GetSampler() const {
+        return this->sampler;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/sampler.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/sampler.cpp
@@ -32,7 +32,7 @@ namespace Vk
         createInfo.minLod = 0.0f;
         createInfo.maxLod = 16.0f;
 
-        BX_ASSERT(!vkCreateSampler(device->GetDevice(), &createInfo, nullptr, &this->sampler),
+        VK_ASSERT(!vkCreateSampler(device->GetDevice(), &createInfo, nullptr, &this->sampler),
             "Failed to create sampler.");
         DebugNames::Set(*device, VK_OBJECT_TYPE_SAMPLER,
             reinterpret_cast<uint64_t>(this->sampler), name);

--- a/src/bx/engine/modules/graphics/backend/vulkan/semaphore.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/semaphore.cpp
@@ -1,0 +1,41 @@
+#include "bx/engine/modules/graphics/backend/vulkan/semaphore.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    Semaphore::Semaphore(const std::string& name, std::shared_ptr<Device> device)
+        : device(device) {
+        VkSemaphoreCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+        BX_ASSERT(!vkCreateSemaphore(device->GetDevice(), &createInfo, nullptr, &this->semaphore),
+            "Failed to create semaphore.");
+        DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_SEMAPHORE,
+            reinterpret_cast<uint64_t>(this->semaphore), name);
+    }
+
+    Semaphore::Semaphore(Semaphore&& other) noexcept
+        : semaphore(other.semaphore), device(other.device) {
+        other.semaphore = VK_NULL_HANDLE;
+    }
+
+    Semaphore& Semaphore::operator=(Semaphore&& other) noexcept {
+        this->semaphore = other.semaphore;
+        other.semaphore = VK_NULL_HANDLE;
+        return *this;
+    }
+
+    Semaphore::~Semaphore() {
+        if (this->semaphore) {
+            vkDestroySemaphore(this->device->GetDevice(), this->semaphore, nullptr);
+        }
+    }
+
+    VkSemaphore Semaphore::GetSemaphore() const {
+        return this->semaphore;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/semaphore.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/semaphore.cpp
@@ -12,7 +12,7 @@ namespace Vk
         VkSemaphoreCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
-        BX_ASSERT(!vkCreateSemaphore(device->GetDevice(), &createInfo, nullptr, &this->semaphore),
+        VK_ASSERT(!vkCreateSemaphore(device->GetDevice(), &createInfo, nullptr, &this->semaphore),
             "Failed to create semaphore.");
         DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_SEMAPHORE,
             reinterpret_cast<uint64_t>(this->semaphore), name);

--- a/src/bx/engine/modules/graphics/backend/vulkan/shader.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/shader.cpp
@@ -1,0 +1,50 @@
+#include "bx/engine/modules/graphics/backend/vulkan/shader.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/spirv_compiler.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+namespace Vk
+{
+    glslang_stage_t GlslangStageFromVkStage(VkShaderStageFlagBits stage)
+    {
+        switch (stage)
+        {
+        case VK_SHADER_STAGE_VERTEX_BIT:
+            return GLSLANG_STAGE_VERTEX;
+        case VK_SHADER_STAGE_GEOMETRY_BIT:
+            return GLSLANG_STAGE_GEOMETRY;
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            return GLSLANG_STAGE_FRAGMENT;
+        case VK_SHADER_STAGE_COMPUTE_BIT:
+            return GLSLANG_STAGE_COMPUTE;
+        default:
+            BX_FAIL("Unsupported shader stage.");
+        }
+    }
+
+    Shader::Shader(const String& name, std::shared_ptr<Device> device, VkShaderStageFlagBits stage, const String& src)
+        : device(device) {
+        List<u32> code = SpirVCompiler::Instance().Compile(name, GlslangStageFromVkStage(stage), src);
+
+        VkShaderModuleCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        createInfo.codeSize = code.size() * 4;
+        createInfo.pCode = reinterpret_cast<const u32*>(code.data());
+
+        BX_ASSERT(!vkCreateShaderModule(device->GetDevice(), &createInfo, nullptr, &this->shader),
+            "Failed to create shader.");
+        DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_SHADER_MODULE,
+            reinterpret_cast<uint64_t>(this->shader), name);
+    }
+
+    Shader::~Shader() {
+        vkDestroyShaderModule(this->device->GetDevice(), this->shader, nullptr);
+    }
+
+    VkShaderModule Shader::GetShader() const {
+        return this->shader;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/shader.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/shader.cpp
@@ -34,7 +34,7 @@ namespace Vk
         createInfo.codeSize = code.size() * 4;
         createInfo.pCode = reinterpret_cast<const u32*>(code.data());
 
-        BX_ASSERT(!vkCreateShaderModule(device->GetDevice(), &createInfo, nullptr, &this->shader),
+        VK_ASSERT(!vkCreateShaderModule(device->GetDevice(), &createInfo, nullptr, &this->shader),
             "Failed to create shader.");
         DebugNames::Set(*device, VkObjectType::VK_OBJECT_TYPE_SHADER_MODULE,
             reinterpret_cast<uint64_t>(this->shader), name);

--- a/src/bx/engine/modules/graphics/backend/vulkan/spirv_compiler.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/spirv_compiler.cpp
@@ -1,0 +1,217 @@
+#include "bx/engine/modules/graphics/backend/vulkan/spirv_compiler.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include <glslang/Include/glslang_c_interface.h>
+#include <glslang/Public/resource_limits_c.h>
+#include <glslang/Public/ResourceLimits.h>
+
+static const TBuiltInResource DefaultTBuiltInResource =
+{
+    /* .MaxLights = */ 32,
+    /* .MaxClipPlanes = */ 6,
+    /* .MaxTextureUnits = */ 32,
+    /* .MaxTextureCoords = */ 32,
+    /* .MaxVertexAttribs = */ 64,
+    /* .MaxVertexUniformComponents = */ 4096,
+    /* .MaxVaryingFloats = */ 64,
+    /* .MaxVertexTextureImageUnits = */ 32,
+    /* .MaxCombinedTextureImageUnits = */ 80,
+    /* .MaxTextureImageUnits = */ 32,
+    /* .MaxFragmentUniformComponents = */ 4096,
+    /* .MaxDrawBuffers = */ 32,
+    /* .MaxVertexUniformVectors = */ 128,
+    /* .MaxVaryingVectors = */ 8,
+    /* .MaxFragmentUniformVectors = */ 16,
+    /* .MaxVertexOutputVectors = */ 16,
+    /* .MaxFragmentInputVectors = */ 15,
+    /* .MinProgramTexelOffset = */ -8,
+    /* .MaxProgramTexelOffset = */ 7,
+    /* .MaxClipDistances = */ 8,
+    /* .MaxComputeWorkGroupCountX = */ 65535,
+    /* .MaxComputeWorkGroupCountY = */ 65535,
+    /* .MaxComputeWorkGroupCountZ = */ 65535,
+    /* .MaxComputeWorkGroupSizeX = */ 1024,
+    /* .MaxComputeWorkGroupSizeY = */ 1024,
+    /* .MaxComputeWorkGroupSizeZ = */ 64,
+    /* .MaxComputeUniformComponents = */ 1024,
+    /* .MaxComputeTextureImageUnits = */ 16,
+    /* .MaxComputeImageUniforms = */ 8,
+    /* .MaxComputeAtomicCounters = */ 8,
+    /* .MaxComputeAtomicCounterBuffers = */ 1,
+    /* .MaxVaryingComponents = */ 60,
+    /* .MaxVertexOutputComponents = */ 64,
+    /* .MaxGeometryInputComponents = */ 64,
+    /* .MaxGeometryOutputComponents = */ 128,
+    /* .MaxFragmentInputComponents = */ 128,
+    /* .MaxImageUnits = */ 8,
+    /* .MaxCombinedImageUnitsAndFragmentOutputs = */ 8,
+    /* .MaxCombinedShaderOutputResources = */ 8,
+    /* .MaxImageSamples = */ 0,
+    /* .MaxVertexImageUniforms = */ 0,
+    /* .MaxTessControlImageUniforms = */ 0,
+    /* .MaxTessEvaluationImageUniforms = */ 0,
+    /* .MaxGeometryImageUniforms = */ 0,
+    /* .MaxFragmentImageUniforms = */ 8,
+    /* .MaxCombinedImageUniforms = */ 8,
+    /* .MaxGeometryTextureImageUnits = */ 16,
+    /* .MaxGeometryOutputVertices = */ 256,
+    /* .MaxGeometryTotalOutputComponents = */ 1024,
+    /* .MaxGeometryUniformComponents = */ 1024,
+    /* .MaxGeometryVaryingComponents = */ 64,
+    /* .MaxTessControlInputComponents = */ 128,
+    /* .MaxTessControlOutputComponents = */ 128,
+    /* .MaxTessControlTextureImageUnits = */ 16,
+    /* .MaxTessControlUniformComponents = */ 1024,
+    /* .MaxTessControlTotalOutputComponents = */ 4096,
+    /* .MaxTessEvaluationInputComponents = */ 128,
+    /* .MaxTessEvaluationOutputComponents = */ 128,
+    /* .MaxTessEvaluationTextureImageUnits = */ 16,
+    /* .MaxTessEvaluationUniformComponents = */ 1024,
+    /* .MaxTessPatchComponents = */ 120,
+    /* .MaxPatchVertices = */ 32,
+    /* .MaxTessGenLevel = */ 64,
+    /* .MaxViewports = */ 16,
+    /* .MaxVertexAtomicCounters = */ 0,
+    /* .MaxTessControlAtomicCounters = */ 0,
+    /* .MaxTessEvaluationAtomicCounters = */ 0,
+    /* .MaxGeometryAtomicCounters = */ 0,
+    /* .MaxFragmentAtomicCounters = */ 8,
+    /* .MaxCombinedAtomicCounters = */ 8,
+    /* .MaxAtomicCounterBindings = */ 1,
+    /* .MaxVertexAtomicCounterBuffers = */ 0,
+    /* .MaxTessControlAtomicCounterBuffers = */ 0,
+    /* .MaxTessEvaluationAtomicCounterBuffers = */ 0,
+    /* .MaxGeometryAtomicCounterBuffers = */ 0,
+    /* .MaxFragmentAtomicCounterBuffers = */ 1,
+    /* .MaxCombinedAtomicCounterBuffers = */ 1,
+    /* .MaxAtomicCounterBufferSize = */ 16384,
+    /* .MaxTransformFeedbackBuffers = */ 4,
+    /* .MaxTransformFeedbackInterleavedComponents = */ 64,
+    /* .MaxCullDistances = */ 8,
+    /* .MaxCombinedClipAndCullDistances = */ 8,
+    /* .MaxSamples = */ 4,
+    /* .maxMeshOutputVerticesNV = */ 256,
+    /* .maxMeshOutputPrimitivesNV = */ 512,
+    /* .maxMeshWorkGroupSizeX_NV = */ 32,
+    /* .maxMeshWorkGroupSizeY_NV = */ 1,
+    /* .maxMeshWorkGroupSizeZ_NV = */ 1,
+    /* .maxTaskWorkGroupSizeX_NV = */ 32,
+    /* .maxTaskWorkGroupSizeY_NV = */ 1,
+    /* .maxTaskWorkGroupSizeZ_NV = */ 1,
+    /* .maxMeshViewCountNV = */ 4,
+    /* .maxMeshOutputVerticesEXT = */ 256,
+    /* .maxMeshOutputPrimitivesEXT = */ 256,
+    /* .maxMeshWorkGroupSizeX_EXT = */ 128,
+    /* .maxMeshWorkGroupSizeY_EXT = */ 128,
+    /* .maxMeshWorkGroupSizeZ_EXT = */ 128,
+    /* .maxTaskWorkGroupSizeX_EXT = */ 128,
+    /* .maxTaskWorkGroupSizeY_EXT = */ 128,
+    /* .maxTaskWorkGroupSizeZ_EXT = */ 128,
+    /* .maxMeshViewCountEXT = */ 4,
+    /* .maxDualSourceDrawBuffersEXT = */ 1,
+
+    /* .limits = */
+    {
+        /* .nonInductiveForLoops = */ 1,
+        /* .whileLoops = */ 1,
+        /* .doWhileLoops = */ 1,
+        /* .generalUniformIndexing = */ 1,
+        /* .generalAttributeMatrixVectorIndexing = */ 1,
+        /* .generalVaryingIndexing = */ 1,
+        /* .generalSamplerIndexing = */ 1,
+        /* .generalVariableIndexing = */ 1,
+        /* .generalConstantMatrixVectorIndexing = */ 1,
+    }
+};
+
+namespace Vk
+{
+    SpirVCompiler& SpirVCompiler::Instance()
+    {
+        static SpirVCompiler instance{};
+        return instance;
+    }
+
+    SpirVCompiler::SpirVCompiler()
+    {
+        glslang_initialize_process();
+    }
+
+    SpirVCompiler::~SpirVCompiler()
+    {
+        glslang_finalize_process();
+    }
+
+    List<u32> SpirVCompiler::Compile(const String& name, glslang_stage_t stage, const String& src)
+    {
+        glslang_input_t input{};
+        input.language = GLSLANG_SOURCE_GLSL;
+        input.stage = stage;
+        input.client = GLSLANG_CLIENT_VULKAN;
+        input.client_version = GLSLANG_TARGET_VULKAN_1_0;
+        input.target_language = GLSLANG_TARGET_SPV;
+        input.target_language_version = GLSLANG_TARGET_SPV_1_0;
+        input.code = src.c_str();
+        input.default_version = 100;
+        input.default_profile = GLSLANG_CORE_PROFILE;
+        input.force_default_version_and_profile = false;
+        input.forward_compatible = false;
+        input.messages = GLSLANG_MSG_DEFAULT_BIT;
+        input.resource = reinterpret_cast<const glslang_resource_t*>(&DefaultTBuiltInResource);
+
+        glslang_shader_t* shader = glslang_shader_create(&input);
+
+        if (!glslang_shader_preprocess(shader, &input))
+        {
+            BX_LOGE("GLSL Preprocessing: `{}`\n{}\n{}",
+                name,
+                glslang_shader_get_info_log(shader),
+                glslang_shader_get_info_debug_log(shader));
+            glslang_shader_delete(shader);
+            return List<u32>{};
+        }
+
+        if (!glslang_shader_parse(shader, &input))
+        {
+            BX_LOGE("GLSL Parsing: `{}`\n{}\n{}",
+                name,
+                glslang_shader_get_info_log(shader),
+                glslang_shader_get_info_debug_log(shader));
+            glslang_shader_delete(shader);
+            return List<u32>{};
+        }
+
+        glslang_program_t* program = glslang_program_create();
+        glslang_program_add_shader(program, shader);
+
+        if (!glslang_program_link(program, GLSLANG_MSG_SPV_RULES_BIT | GLSLANG_MSG_VULKAN_RULES_BIT))
+        {
+            BX_LOGE("GLSL Linking: `{}`\n{}\n{}",
+                name,
+                glslang_shader_get_info_log(shader),
+                glslang_shader_get_info_debug_log(shader));
+            glslang_shader_delete(shader);
+            glslang_program_delete(program);
+            glslang_shader_delete(shader);
+            return List<u32>{};
+        }
+
+        glslang_program_SPIRV_generate(program, stage);
+
+        SizeType size = glslang_program_SPIRV_get_size(program);
+        List<u32> words(size);
+        glslang_program_SPIRV_get(program, words.data());
+
+        const char* spirv_messages = glslang_program_SPIRV_get_messages(program);
+        if (spirv_messages)
+        {
+            BX_LOGW("GLSL: `{}`\n{}", name, spirv_messages);
+        }
+
+        glslang_program_delete(program);
+        glslang_shader_delete(shader);
+
+        return words;
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -30,7 +30,7 @@ namespace Vk
             formats.data()));
 
         for (const auto& availableFormat : formats) {
-            if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB &&
+            if (availableFormat.format == VK_FORMAT_B8G8R8A8_UNORM &&
                 availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
                 return availableFormat;
             }
@@ -112,7 +112,7 @@ namespace Vk
 
         TextureCreateInfo imageCreateInfo{};
         imageCreateInfo.name = "Swapchain Color Target";
-        imageCreateInfo.format = TextureFormat::BGRA8_UNORM_SRGB; // TODO: see ChooseSwapSurfaceFormat()
+        imageCreateInfo.format = TextureFormat::BGRA8_UNORM; // TODO: see ChooseSwapSurfaceFormat()
         imageCreateInfo.size = Extend3D(extent.width, extent.height, 1);
         imageCreateInfo.usageFlags = TextureUsageFlags::COPY_DST | TextureUsageFlags::RENDER_ATTACHMENT;
         this->imageCreateInfo = imageCreateInfo;

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -1,0 +1,273 @@
+#include "bx/engine/modules/graphics/backend/vulkan/swapchain.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/instance.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/physical_device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/render_pass.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/image.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/framebuffer.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/semaphore.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/fence.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/rect2d.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
+
+namespace Vk
+{
+    VkSurfaceFormatKHR ChooseSwapSurfaceFormat(const Instance& instance,
+        const PhysicalDevice& physicalDevice) {
+        uint32_t formatCount;
+        BX_ENSURE(!vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice.GetPhysicalDevice(),
+            instance.GetSurface(), &formatCount, nullptr));
+        BX_ASSERT(formatCount > 0, "No swapchain formats found.");
+
+        std::vector<VkSurfaceFormatKHR> formats(formatCount);
+        BX_ENSURE(!vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice.GetPhysicalDevice(),
+            instance.GetSurface(), &formatCount,
+            formats.data()));
+
+        for (const auto& availableFormat : formats) {
+            if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB &&
+                availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+                return availableFormat;
+            }
+        }
+
+        return formats[0];
+    }
+
+    VkPresentModeKHR ChooseSwapPresentMode(const Instance& instance,
+        const PhysicalDevice& physicalDevice) {
+        uint32_t presentModeCount;
+        BX_ENSURE(!vkGetPhysicalDeviceSurfacePresentModesKHR(
+            physicalDevice.GetPhysicalDevice(), instance.GetSurface(), &presentModeCount, nullptr));
+        BX_ASSERT(presentModeCount > 0, "No present modes found.");
+
+        std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+        BX_ENSURE(!vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice.GetPhysicalDevice(),
+            instance.GetSurface(), &presentModeCount,
+            presentModes.data()));
+
+        for (const auto& availablePresentMode : presentModes) {
+            if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
+                return availablePresentMode;
+            }
+        }
+
+        return VK_PRESENT_MODE_FIFO_KHR;
+    }
+
+    VkExtent2D ChooseSwapExtent(uint32_t width, uint32_t height, const Instance& instance,
+        const PhysicalDevice& physicalDevice) {
+        VkSurfaceCapabilitiesKHR capabilities;
+        BX_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
+            instance.GetSurface(), &capabilities));
+
+        VkExtent2D extent;
+        if (capabilities.currentExtent.width != UINT_MAX) {
+            extent = capabilities.currentExtent;
+        }
+        else {
+            extent = { width, height };
+
+            extent.width = Math::Clamp(extent.width, capabilities.minImageExtent.width,
+                capabilities.maxImageExtent.width);
+            extent.height = Math::Clamp(extent.height, capabilities.minImageExtent.height,
+                capabilities.maxImageExtent.height);
+        }
+
+        extent.width = std::max(2U, extent.width);
+        extent.height = std::max(2U, extent.height);
+
+        return extent;
+    }
+
+    uint32_t ChooseImageCount(const Instance& instance,
+        const PhysicalDevice& physicalDevice) {
+        VkSurfaceCapabilitiesKHR capabilities;
+        BX_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
+            instance.GetSurface(), &capabilities));
+
+        uint32_t imageCount = capabilities.minImageCount + 1;
+        if (capabilities.maxImageCount > 0 && imageCount > capabilities.maxImageCount) {
+            imageCount = capabilities.maxImageCount;
+        }
+        return imageCount;
+    }
+
+    Swapchain::Swapchain(uint32_t width, uint32_t height, const Instance& instance,
+        std::shared_ptr<Device> device,
+        const PhysicalDevice& physicalDevice)
+        : currentFrame(0), currentImage(0), device(device) {
+        this->format = ChooseSwapSurfaceFormat(instance, physicalDevice);
+        this->presentMode = ChooseSwapPresentMode(instance, physicalDevice);
+        this->extent = ChooseSwapExtent(width, height, instance, physicalDevice);
+        this->imageCount = ChooseImageCount(instance, physicalDevice);
+
+        VkSurfaceCapabilitiesKHR capabilities;
+        BX_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
+            instance.GetSurface(), &capabilities));
+
+        VkSwapchainCreateInfoKHR createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+        createInfo.surface = instance.GetSurface();
+        createInfo.minImageCount = this->imageCount;
+        createInfo.imageFormat = this->format.format;
+        createInfo.imageColorSpace = this->format.colorSpace;
+        createInfo.imageExtent = this->extent;
+        createInfo.imageArrayLayers = 1;
+        createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+#if defined BX_PLATFORM_PC || defined BX_PLATFORM_LINUX
+        createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+        createInfo.preTransform = capabilities.currentTransform;
+#else
+        BX_FAIL("Unimplemented");
+#endif
+        createInfo.presentMode = this->presentMode;
+        createInfo.clipped = VK_TRUE;
+
+        if (physicalDevice.GraphicsFamily() != physicalDevice.PresentFamily()) {
+            uint32_t queueFamilyIndices[] = { physicalDevice.GraphicsFamily(),
+                                             physicalDevice.PresentFamily() };
+
+            createInfo.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
+            createInfo.queueFamilyIndexCount = 2;
+            createInfo.pQueueFamilyIndices = queueFamilyIndices;
+        }
+        else {
+            createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        }
+
+        BX_ASSERT(!vkCreateSwapchainKHR(device->GetDevice(), &createInfo, nullptr, &this->swapchain),
+            "Failed to create swapchain.");
+
+        vkGetSwapchainImagesKHR(device->GetDevice(), this->swapchain, &this->imageCount, nullptr);
+        std::vector<VkImage> swapChainImages(this->imageCount);
+        vkGetSwapchainImagesKHR(device->GetDevice(), this->swapchain, &this->imageCount,
+            swapChainImages.data());
+
+        std::vector<VkImageView> swapChainImageViews(swapChainImages.size());
+        for (size_t i = 0; i < swapChainImages.size(); i++) {
+            VkImageViewCreateInfo createInfo{};
+            createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            createInfo.image = swapChainImages[i];
+            createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            createInfo.format = this->format.format;
+            createInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+            createInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+            createInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+            createInfo.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+            createInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            createInfo.subresourceRange.baseMipLevel = 0;
+            createInfo.subresourceRange.levelCount = 1;
+            createInfo.subresourceRange.baseArrayLayer = 0;
+            createInfo.subresourceRange.layerCount = 1;
+
+            BX_ASSERT(!vkCreateImageView(device->GetDevice(), &createInfo, nullptr,
+                &swapChainImageViews[i]),
+                "Failed to create image view.");
+        }
+
+        this->images.reserve(swapChainImages.size());
+        for (size_t i = 0; i < swapChainImages.size(); i++) {
+            this->images.push_back(
+                std::make_shared<Image>(Log::Format("Swapchain Image {}", i), device, swapChainImages[i], swapChainImageViews[i],
+                    this->extent.width, this->extent.height));
+
+            ImageState imageState;
+            imageState.layout = VkImageLayout::VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+            imageState.stageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+            imageState.accessFlags =
+                VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;  // VkAccessFlagBits::VK_ACCESS_NONE;
+            ResourceStateTracker::AddGlobalImageState(this->images[i]->GetImage(), imageState);
+        }
+
+        for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
+            imageAvailableSemaphores.emplace_back(
+                Semaphore(Log::Format("Image Available {}", i), device));
+            renderFinishedSemaphores.emplace_back(
+                Semaphore(Log::Format("Render Finished {}", i), device));
+            inFlightFences.emplace_back(std::make_shared<Fence>(Log::Format("Swapchain In Flight Fence {}", i), device, true));
+        }
+
+        this->renderPass = std::make_shared<RenderPass>("Swapchain Render Pass",
+            this->device, std::vector<VkFormat>{this->Format()}, Optional<VkFormat>::None());
+        for (auto& image : this->images) {
+            std::vector<std::shared_ptr<Image>> images{ image };
+            this->framebuffers.emplace_back(
+                Framebuffer("Swapchain Framebuffer", this->device, images, this->renderPass));
+        }
+    }
+
+    Swapchain::~Swapchain() {
+        vkDestroySwapchainKHR(this->device->GetDevice(), this->swapchain, nullptr);
+    }
+
+    const Framebuffer& Swapchain::GetCurrentFramebuffer() const {
+        BX_ASSERT(!this->framebuffers.empty(), "Rebuild framebuffers first!");
+        return this->framebuffers[static_cast<size_t>(this->currentImage)];
+    }
+
+    const Image& Swapchain::GetCurrentImage() const {
+        return *this->images[static_cast<size_t>(this->currentImage)];
+    }
+
+    uint32_t Swapchain::GetCurrentFrameIdx() const {
+        return this->currentFrame;
+    }
+
+    Semaphore& Swapchain::GetImageAvailableSemaphore() {
+        return this->imageAvailableSemaphores[static_cast<size_t>(this->currentFrame)];
+    }
+
+    Semaphore& Swapchain::GetRenderFinishedSemaphore() {
+        return this->renderFinishedSemaphores[static_cast<size_t>(this->currentFrame)];
+    }
+
+    std::shared_ptr<RenderPass> Swapchain::GetRenderPass() {
+        return this->renderPass;
+    }
+
+    std::shared_ptr<Fence> Swapchain::NextImage() {
+        this->inFlightFences[this->currentFrame]->Wait();
+        this->inFlightFences[this->currentFrame]->Reset();
+
+        vkAcquireNextImageKHR(
+            this->device->GetDevice(), this->swapchain, std::numeric_limits<uint64_t>::max(),
+            this->GetImageAvailableSemaphore().GetSemaphore(), VK_NULL_HANDLE, &this->currentImage);
+
+        return this->inFlightFences[this->currentFrame];
+    }
+
+    void Swapchain::Present(const CmdQueue& queue, const Fence& fence,
+        const std::vector<Semaphore*>& semaphores) {
+        std::vector<VkSemaphore> vkSemaphores;
+        for (auto& semaphore : semaphores) {
+            vkSemaphores.push_back(semaphore->GetSemaphore());
+        }
+
+        VkPresentInfoKHR presentInfo{};
+        presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+        presentInfo.waitSemaphoreCount = static_cast<uint32_t>(vkSemaphores.size());
+        presentInfo.pWaitSemaphores = vkSemaphores.data();
+        VkSwapchainKHR swapChains[] = { this->swapchain };
+        presentInfo.swapchainCount = 1;
+        presentInfo.pSwapchains = swapChains;
+        presentInfo.pImageIndices = &this->currentImage;
+
+        vkQueuePresentKHR(queue.GetQueue(), &presentInfo);
+
+        this->currentFrame = (this->currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
+    }
+
+    VkFormat Swapchain::Format() const {
+        return this->format.format;
+    }
+
+    Rect2D Swapchain::Extent() const {
+        return Rect2D(static_cast<float>(this->extent.width),
+            static_cast<float>(this->extent.height));
+    }
+}

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -200,9 +200,11 @@ namespace Vk
                 Semaphore(Log::Format("Render Finished {}", i), device));
             inFlightFences.emplace_back(std::make_shared<Fence>(Log::Format("Swapchain In Flight Fence {}", i), device, true));
         }
-
+        
+        RenderPassInfo renderPassInfo{};
+        renderPassInfo.colorFormats = { this->Format() };
         this->renderPass = std::make_shared<RenderPass>("Swapchain Render Pass",
-            this->device, std::vector<VkFormat>{this->Format()}, Optional<VkFormat>::None());
+            this->device, renderPassInfo);
         for (auto& image : this->images) {
             std::vector<std::shared_ptr<Image>> images{ image };
             this->framebuffers.emplace_back(

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -36,6 +36,7 @@ namespace Vk
             }
         }
 
+        BX_FAIL("TODO: update create info to support this.");
         return formats[0];
     }
 
@@ -106,6 +107,13 @@ namespace Vk
         this->presentMode = ChooseSwapPresentMode(instance, physicalDevice);
         this->extent = ChooseSwapExtent(width, height, instance, physicalDevice);
         this->imageCount = ChooseImageCount(instance, physicalDevice);
+
+        TextureCreateInfo imageCreateInfo{};
+        imageCreateInfo.name = "Swapchain Color Target";
+        imageCreateInfo.format = TextureFormat::BGRA8_UNORM_SRGB; // TODO: see ChooseSwapSurfaceFormat()
+        imageCreateInfo.size = Extend3D(extent.width, extent.height, 1);
+        imageCreateInfo.usageFlags = TextureUsageFlags::COPY_DST | TextureUsageFlags::RENDER_ATTACHMENT;
+        this->imageCreateInfo = imageCreateInfo;
 
         VkSurfaceCapabilitiesKHR capabilities;
         VK_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
@@ -204,6 +212,16 @@ namespace Vk
 
     Swapchain::~Swapchain() {
         vkDestroySwapchainKHR(this->device->GetDevice(), this->swapchain, nullptr);
+    }
+
+    TextureCreateInfo Swapchain::GetImageCreateInfo() const
+    {
+        return imageCreateInfo;
+    }
+
+    std::shared_ptr<Image> Swapchain::GetImage(u32 idx) const
+    {
+        return this->images[idx];
     }
 
     const Framebuffer& Swapchain::GetCurrentFramebuffer() const {

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -184,8 +184,8 @@ namespace Vk
         this->images.reserve(swapChainImages.size());
         for (size_t i = 0; i < swapChainImages.size(); i++) {
             this->images.push_back(
-                std::make_shared<Image>(Log::Format("Swapchain Image {}", i), device, swapChainImages[i], swapChainImageViews[i],
-                    this->extent.width, this->extent.height));
+                std::shared_ptr<Image>(new Image(Log::Format("Swapchain Image {}", i), device, swapChainImages[i], swapChainImageViews[i],
+                    this->extent.width, this->extent.height)));
 
             ImageState imageState;
             imageState.currentLayout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
@@ -198,14 +198,14 @@ namespace Vk
                 Semaphore(Log::Format("Image Available {}", i), device));
             renderFinishedSemaphores.emplace_back(
                 Semaphore(Log::Format("Render Finished {}", i), device));
-            inFlightFences.emplace_back(std::make_shared<Fence>(Log::Format("Swapchain In Flight Fence {}", i), device, true));
+            inFlightFences.emplace_back(std::shared_ptr<Fence>(new Fence(Log::Format("Swapchain In Flight Fence {}", i), device, true)));
         }
         
         RenderPassInfo renderPassInfo{};
         renderPassInfo.colorFormats = { this->Format() };
         renderPassInfo.clear = false;
-        this->renderPass = std::make_shared<RenderPass>("Swapchain Render Pass",
-            this->device, renderPassInfo);
+        this->renderPass = std::shared_ptr<RenderPass>(new RenderPass("Swapchain Render Pass",
+            this->device, renderPassInfo));
         for (auto& image : this->images) {
             FramebufferInfo framebufferInfo{};
             framebufferInfo.images = { image };

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -203,6 +203,7 @@ namespace Vk
         
         RenderPassInfo renderPassInfo{};
         renderPassInfo.colorFormats = { this->Format() };
+        renderPassInfo.clear = false;
         this->renderPass = std::make_shared<RenderPass>("Swapchain Render Pass",
             this->device, renderPassInfo);
         for (auto& image : this->images) {

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -106,7 +106,9 @@ namespace Vk
         this->format = ChooseSwapSurfaceFormat(instance, physicalDevice);
         this->presentMode = ChooseSwapPresentMode(instance, physicalDevice);
         this->extent = ChooseSwapExtent(width, height, instance, physicalDevice);
-        this->imageCount = ChooseImageCount(instance, physicalDevice);
+
+        // TODO: fix this absolute chaos
+        this->imageCount = MAX_FRAMES_IN_FLIGHT;// ChooseImageCount(instance, physicalDevice);
 
         TextureCreateInfo imageCreateInfo{};
         imageCreateInfo.name = "Swapchain Color Target";
@@ -186,10 +188,8 @@ namespace Vk
                     this->extent.width, this->extent.height));
 
             ImageState imageState;
-            imageState.currentLayout = VkImageLayout::VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+            imageState.currentLayout = VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED;
             imageState.lastStageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-            //imageState.accessFlags =
-            //    VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;  // VkAccessFlagBits::VK_ACCESS_NONE;
             ResourceStateTracker::AddGlobalImageState(this->images[i]->GetImage(), imageState);
         }
 
@@ -260,6 +260,7 @@ namespace Vk
         vkAcquireNextImageKHR(
             this->device->GetDevice(), this->swapchain, std::numeric_limits<uint64_t>::max(),
             this->GetImageAvailableSemaphore().GetSemaphore(), VK_NULL_HANDLE, &this->currentImage);
+        BX_ENSURE(this->currentImage < MAX_FRAMES_IN_FLIGHT);
 
         return this->inFlightFences[this->currentFrame];
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -186,10 +186,10 @@ namespace Vk
                     this->extent.width, this->extent.height));
 
             ImageState imageState;
-            imageState.layout = VkImageLayout::VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-            imageState.stageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-            imageState.accessFlags =
-                VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;  // VkAccessFlagBits::VK_ACCESS_NONE;
+            imageState.currentLayout = VkImageLayout::VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+            imageState.lastStageFlags = VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+            //imageState.accessFlags =
+            //    VkAccessFlagBits::VK_ACCESS_SHADER_READ_BIT;  // VkAccessFlagBits::VK_ACCESS_NONE;
             ResourceStateTracker::AddGlobalImageState(this->images[i]->GetImage(), imageState);
         }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -206,9 +206,11 @@ namespace Vk
         this->renderPass = std::make_shared<RenderPass>("Swapchain Render Pass",
             this->device, renderPassInfo);
         for (auto& image : this->images) {
-            std::vector<std::shared_ptr<Image>> images{ image };
+            FramebufferInfo framebufferInfo{};
+            framebufferInfo.images = { image };
+            framebufferInfo.renderPass = this->renderPass;
             this->framebuffers.emplace_back(
-                Framebuffer("Swapchain Framebuffer", this->device, images, this->renderPass));
+                Framebuffer("Swapchain Framebuffer", this->device, framebufferInfo));
         }
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -13,18 +13,19 @@
 #include "bx/engine/modules/graphics/backend/vulkan/cmd_queue.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/rect2d.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/resource_state_tracker.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
 
 namespace Vk
 {
     VkSurfaceFormatKHR ChooseSwapSurfaceFormat(const Instance& instance,
         const PhysicalDevice& physicalDevice) {
         uint32_t formatCount;
-        BX_ENSURE(!vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice.GetPhysicalDevice(),
+        VK_ENSURE(!vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice.GetPhysicalDevice(),
             instance.GetSurface(), &formatCount, nullptr));
-        BX_ASSERT(formatCount > 0, "No swapchain formats found.");
+        VK_ASSERT(formatCount > 0, "No swapchain formats found.");
 
         std::vector<VkSurfaceFormatKHR> formats(formatCount);
-        BX_ENSURE(!vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice.GetPhysicalDevice(),
+        VK_ENSURE(!vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice.GetPhysicalDevice(),
             instance.GetSurface(), &formatCount,
             formats.data()));
 
@@ -41,12 +42,12 @@ namespace Vk
     VkPresentModeKHR ChooseSwapPresentMode(const Instance& instance,
         const PhysicalDevice& physicalDevice) {
         uint32_t presentModeCount;
-        BX_ENSURE(!vkGetPhysicalDeviceSurfacePresentModesKHR(
+        VK_ENSURE(!vkGetPhysicalDeviceSurfacePresentModesKHR(
             physicalDevice.GetPhysicalDevice(), instance.GetSurface(), &presentModeCount, nullptr));
-        BX_ASSERT(presentModeCount > 0, "No present modes found.");
+        VK_ASSERT(presentModeCount > 0, "No present modes found.");
 
         std::vector<VkPresentModeKHR> presentModes(presentModeCount);
-        BX_ENSURE(!vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice.GetPhysicalDevice(),
+        VK_ENSURE(!vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice.GetPhysicalDevice(),
             instance.GetSurface(), &presentModeCount,
             presentModes.data()));
 
@@ -62,7 +63,7 @@ namespace Vk
     VkExtent2D ChooseSwapExtent(uint32_t width, uint32_t height, const Instance& instance,
         const PhysicalDevice& physicalDevice) {
         VkSurfaceCapabilitiesKHR capabilities;
-        BX_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
+        VK_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
             instance.GetSurface(), &capabilities));
 
         VkExtent2D extent;
@@ -87,7 +88,7 @@ namespace Vk
     uint32_t ChooseImageCount(const Instance& instance,
         const PhysicalDevice& physicalDevice) {
         VkSurfaceCapabilitiesKHR capabilities;
-        BX_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
+        VK_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
             instance.GetSurface(), &capabilities));
 
         uint32_t imageCount = capabilities.minImageCount + 1;
@@ -107,7 +108,7 @@ namespace Vk
         this->imageCount = ChooseImageCount(instance, physicalDevice);
 
         VkSurfaceCapabilitiesKHR capabilities;
-        BX_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
+        VK_ENSURE(!vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice.GetPhysicalDevice(),
             instance.GetSurface(), &capabilities));
 
         VkSwapchainCreateInfoKHR createInfo{};
@@ -140,7 +141,7 @@ namespace Vk
             createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
         }
 
-        BX_ASSERT(!vkCreateSwapchainKHR(device->GetDevice(), &createInfo, nullptr, &this->swapchain),
+        VK_ASSERT(!vkCreateSwapchainKHR(device->GetDevice(), &createInfo, nullptr, &this->swapchain),
             "Failed to create swapchain.");
 
         vkGetSwapchainImagesKHR(device->GetDevice(), this->swapchain, &this->imageCount, nullptr);
@@ -165,7 +166,7 @@ namespace Vk
             createInfo.subresourceRange.baseArrayLayer = 0;
             createInfo.subresourceRange.layerCount = 1;
 
-            BX_ASSERT(!vkCreateImageView(device->GetDevice(), &createInfo, nullptr,
+            VK_ASSERT(!vkCreateImageView(device->GetDevice(), &createInfo, nullptr,
                 &swapChainImageViews[i]),
                 "Failed to create image view.");
         }
@@ -206,7 +207,7 @@ namespace Vk
     }
 
     const Framebuffer& Swapchain::GetCurrentFramebuffer() const {
-        BX_ASSERT(!this->framebuffers.empty(), "Rebuild framebuffers first!");
+        VK_ASSERT(!this->framebuffers.empty(), "Rebuild framebuffers first!");
         return this->framebuffers[static_cast<size_t>(this->currentImage)];
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/swapchain.cpp
@@ -210,7 +210,7 @@ namespace Vk
             framebufferInfo.images = { image };
             framebufferInfo.renderPass = this->renderPass;
             this->framebuffers.emplace_back(
-                Framebuffer("Swapchain Framebuffer", this->device, framebufferInfo));
+                std::shared_ptr<Framebuffer>(new Framebuffer("Swapchain Framebuffer", this->device, framebufferInfo)));
         }
     }
 
@@ -228,7 +228,7 @@ namespace Vk
         return this->images[idx];
     }
 
-    const Framebuffer& Swapchain::GetCurrentFramebuffer() const {
+    std::shared_ptr<Framebuffer> Swapchain::GetCurrentFramebuffer() const {
         VK_ASSERT(!this->framebuffers.empty(), "Rebuild framebuffers first!");
         return this->framebuffers[static_cast<size_t>(this->currentImage)];
     }

--- a/src/bx/engine/modules/graphics/backend/vulkan/validation.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/validation.cpp
@@ -24,7 +24,7 @@ namespace Vk
                 }
             }
 
-            BX_ASSERT(layerFound, "Validation layer '{}' is not supported.", layerName);
+            VK_ASSERT(layerFound, "Validation layer '{}' is not supported.", layerName);
         }
     }
 

--- a/src/bx/engine/modules/graphics/backend/vulkan/validation.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/validation.cpp
@@ -1,0 +1,60 @@
+#include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
+
+#include "bx/engine/core/macros.hpp"
+
+#include "bx/engine/modules/graphics/backend/vulkan/device.hpp"
+#include "bx/engine/modules/graphics/backend/vulkan/pfn.hpp"
+
+namespace Vk
+{
+    void CheckValidationLayerSupport() {
+        uint32_t layerCount;
+        vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
+
+        std::vector<VkLayerProperties> availableLayers(layerCount);
+        vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
+
+        for (const char* layerName : validationLayers) {
+            bool layerFound = false;
+
+            for (const auto& layerProperties : availableLayers) {
+                if (strcmp(layerName, layerProperties.layerName) == 0) {
+                    layerFound = true;
+                    break;
+                }
+            }
+
+            BX_ASSERT(layerFound, "Validation layer '{}' is not supported.", layerName);
+        }
+    }
+
+    VkBool32 VulkanDebugCallback(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType,
+        uint64_t srcObject, size_t location, int32_t msgCode,
+        const char* pLayerPrefix, const char* pMsg, void* pUserData) {
+        if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
+        {
+            BX_LOGE("[{}] {}", pLayerPrefix, pMsg);
+            abort();
+        }
+        else if (msgFlags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
+            BX_LOGW("[{}] {}", pLayerPrefix, pMsg);
+        else if (msgFlags & VK_DEBUG_REPORT_DEBUG_BIT_EXT)
+            BX_LOGI("[{}] {}", pLayerPrefix, pMsg);
+        else if (msgFlags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
+            BX_LOGW("[{}] {}", pLayerPrefix, pMsg);
+        else if (msgFlags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
+            BX_LOGI("[{}] {}", pLayerPrefix, pMsg);
+        return 0;
+    }
+
+    void DebugNames::Set(const Device& device, VkObjectType type, uint64_t handle,
+        const String& name) {
+        VkDebugUtilsObjectNameInfoEXT nameInfo{};
+        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        nameInfo.objectType = type;
+        nameInfo.objectHandle = handle;
+        nameInfo.pObjectName = name.c_str();
+
+        Pfn::vkSetDebugUtilsObjectNameEXT(device.GetDevice(), &nameInfo);
+    }
+}

--- a/src/bx/engine/modules/graphics/type.cpp
+++ b/src/bx/engine/modules/graphics/type.cpp
@@ -210,6 +210,27 @@ b8 IsTextureFormatSrgb(const TextureFormat& format)
 	}
 }
 
+b8 IsTextureFormatDepth(const TextureFormat& format)
+{
+	switch (format)
+	{
+	case TextureFormat::STENCIL8:
+		return true;
+	case TextureFormat::DEPTH16_UNORM:
+		return true;
+	case TextureFormat::DEPTH24_PLUS:
+		return true;
+	case TextureFormat::DEPTH24_PLUS_STENCIL8:
+		return true;
+	case TextureFormat::DEPTH32_FLOAT:
+		return true;
+	case TextureFormat::DEPTH32_FLOAT_STENCIL8:
+		return true;
+	default:
+		return false;
+	}
+}
+
 u32 SizeOfTextureFormat(const TextureFormat& format)
 {
 	switch (format)
@@ -352,4 +373,9 @@ u32 SizeOfTextureFormat(const TextureFormat& format)
 		BX_FAIL("Texture format not supported.");
 		return 0;
 	}
+}
+
+b8 IsBufferUsageMappable(const BufferUsageFlags& usage)
+{
+	return usage & BufferUsageFlags::MAP_READ || usage & BufferUsageFlags::MAP_WRITE;
 }

--- a/src/bx/engine/modules/graphics/type.cpp
+++ b/src/bx/engine/modules/graphics/type.cpp
@@ -215,7 +215,7 @@ b8 IsTextureFormatDepth(const TextureFormat& format)
 	switch (format)
 	{
 	case TextureFormat::STENCIL8:
-		return true;
+		return false;
 	case TextureFormat::DEPTH16_UNORM:
 		return true;
 	case TextureFormat::DEPTH24_PLUS:
@@ -224,6 +224,27 @@ b8 IsTextureFormatDepth(const TextureFormat& format)
 		return true;
 	case TextureFormat::DEPTH32_FLOAT:
 		return true;
+	case TextureFormat::DEPTH32_FLOAT_STENCIL8:
+		return true;
+	default:
+		return false;
+	}
+}
+
+b8 IsTextureFormatStencil(const TextureFormat& format)
+{
+	switch (format)
+	{
+	case TextureFormat::STENCIL8:
+		return true;
+	case TextureFormat::DEPTH16_UNORM:
+		return false;
+	case TextureFormat::DEPTH24_PLUS:
+		return false;
+	case TextureFormat::DEPTH24_PLUS_STENCIL8:
+		return true;
+	case TextureFormat::DEPTH32_FLOAT:
+		return false;
 	case TextureFormat::DEPTH32_FLOAT_STENCIL8:
 		return true;
 	default:

--- a/src/bx/engine/modules/graphics/type.cpp
+++ b/src/bx/engine/modules/graphics/type.cpp
@@ -379,3 +379,9 @@ b8 IsBufferUsageMappable(const BufferUsageFlags& usage)
 {
 	return usage & BufferUsageFlags::MAP_READ || usage & BufferUsageFlags::MAP_WRITE;
 }
+
+u32 SizeOfTexturePixels(const TextureCreateInfo& info)
+{
+	u32 pixels = info.size.width * info.size.height * info.size.depthOrArrayLayers;
+	return pixels * SizeOfTextureFormat(info.format);
+}

--- a/src/bx/framework/components/animator.cpp
+++ b/src/bx/framework/components/animator.cpp
@@ -10,7 +10,7 @@ Animator::Animator()
     BufferCreateInfo createInfo{};
     createInfo.name = "Animator Bones Buffer";
     createInfo.size = sizeof(Mat4) * 100;
-    createInfo.usageFlags = BufferUsageFlags::UNIFORM | BufferUsageFlags::STORAGE;
+    createInfo.usageFlags = BufferUsageFlags::UNIFORM | BufferUsageFlags::STORAGE | BufferUsageFlags::COPY_DST;
     m_boneBuffer = Graphics::CreateBuffer(createInfo);
 }
 

--- a/src/bx/framework/resources/shader.cpp
+++ b/src/bx/framework/resources/shader.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <stdexcept>
 
+
 static String ResolveIncludes(const String& source, HashSet<String>& includedFiles)
 {
     InputStringStream shaderStream(source);
@@ -49,7 +50,7 @@ static String ResolveIncludes(const String& source, HashSet<String>& includedFil
     return resolvedShader.GetString();
 }
 
-static String PreprocessShader(const String& source)
+String ResolveShaderIncludes(const String& source)
 {
     HashSet<String> includedFiles;
     return ResolveIncludes(source, includedFiles);
@@ -77,7 +78,7 @@ bool Resource<Shader>::Load(const String& filename, Shader& data)
     std::stringstream ss;
     ss << stream.rdbuf();
 
-    String source = PreprocessShader(ss.str());
+    String source = ResolveShaderIncludes(ss.str());
     data.SetSource(source);
 
     ShaderCreateInfo vertexCreateInfo{};

--- a/src/bx/framework/resources/texture.cpp
+++ b/src/bx/framework/resources/texture.cpp
@@ -45,7 +45,7 @@ bool Resource<Texture>::Load(const String& filename, Texture& data)
     createInfo.name = filename;
     createInfo.format = TextureFormat::RGBA8_UNORM_SRGB;
     createInfo.size = Extend3D(data.width, data.height, 1);
-    createInfo.usageFlags = TextureUsageFlags::TEXTURE_BINDING | TextureUsageFlags::STORAGE_BINDING | TextureUsageFlags::COPY_SRC;
+    createInfo.usageFlags = TextureUsageFlags::TEXTURE_BINDING | TextureUsageFlags::COPY_SRC;
     createInfo.data = static_cast<const void*>(data.pixels.data());
     data.m_texture = Graphics::CreateTexture(createInfo);
 

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -83,7 +83,7 @@ void BuildShaderPipelines()
             BindGroupLayoutEntry(0, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 0, std140) uniform Constants
             BindGroupLayoutEntry(1, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 1, std140) uniform Model
             BindGroupLayoutEntry(2, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 2, std140) uniform Animation
-            BindGroupLayoutEntry(3, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::Texture(TextureSampleType::FLOAT)),  // layout (binding = 3) uniform sampler2D Albedo
+            //BindGroupLayoutEntry(3, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::Texture(TextureSampleType::FLOAT)),  // layout (binding = 3) uniform sampler2D Albedo
             BindGroupLayoutEntry(4, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::UniformBuffer())                     // layout (binding = 4, std140) uniform LightBuffer
         }),
         Material::GetBindGroupLayout()

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -264,6 +264,7 @@ void Renderer::Update()
 
 void Renderer::Render()
 {
+    return;
     // TODO: this is a better fit for the update method, however, Graphics::Update is called BEFORE all the world does its updating, leaving its state 1 frame behind
     UpdateAnimators();
     UpdateLightSources();

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -264,7 +264,6 @@ void Renderer::Update()
 
 void Renderer::Render()
 {
-    return;
     // TODO: this is a better fit for the update method, however, Graphics::Update is called BEFORE all the world does its updating, leaving its state 1 frame behind
     UpdateAnimators();
     UpdateLightSources();

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -80,10 +80,11 @@ void BuildShaderPipelines()
     PipelineLayoutDescriptor pipelineLayoutDescriptor{};
     pipelineLayoutDescriptor.bindGroupLayouts = {
         BindGroupLayoutDescriptor(0, {
-            BindGroupLayoutEntry(0, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),      // layout (binding = 0, std140) uniform Constants
-            BindGroupLayoutEntry(1, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),      // layout (binding = 1, std140) uniform Model
-            BindGroupLayoutEntry(2, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),      // layout (binding = 2, std140) uniform Animation
-            BindGroupLayoutEntry(4, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::UniformBuffer())     // layout (binding = 4, std140) uniform LightBuffer
+            BindGroupLayoutEntry(0, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 0, std140) uniform Constants
+            BindGroupLayoutEntry(1, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 1, std140) uniform Model
+            BindGroupLayoutEntry(2, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 2, std140) uniform Animation
+            BindGroupLayoutEntry(3, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::Texture(TextureSampleType::FLOAT)),  // layout (binding = 3) uniform sampler2D Albedo
+            BindGroupLayoutEntry(4, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::UniformBuffer())                     // layout (binding = 4, std140) uniform LightBuffer
         }),
         Material::GetBindGroupLayout()
     };

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -83,7 +83,6 @@ void BuildShaderPipelines()
             BindGroupLayoutEntry(0, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 0, std140) uniform Constants
             BindGroupLayoutEntry(1, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 1, std140) uniform Model
             BindGroupLayoutEntry(2, ShaderStageFlags::VERTEX, BindingTypeDescriptor::UniformBuffer()),                      // layout (binding = 2, std140) uniform Animation
-            //BindGroupLayoutEntry(3, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::Texture(TextureSampleType::FLOAT)),  // layout (binding = 3) uniform sampler2D Albedo
             BindGroupLayoutEntry(4, ShaderStageFlags::FRAGMENT, BindingTypeDescriptor::UniformBuffer())                     // layout (binding = 4, std140) uniform LightBuffer
         }),
         Material::GetBindGroupLayout()

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -212,7 +212,7 @@ void RecreateRenderTargets()
         colorTargetCreateInfo.name = "Color Target";
         colorTargetCreateInfo.size = Extend3D(w, h, 1);
         colorTargetCreateInfo.format = TextureFormat::RGBA32_FLOAT;
-        colorTargetCreateInfo.usageFlags = TextureUsageFlags::RENDER_ATTACHMENT;
+        colorTargetCreateInfo.usageFlags = TextureUsageFlags::RENDER_ATTACHMENT | TextureUsageFlags::TEXTURE_BINDING;
         if (s->colorTarget) Graphics::DestroyTexture(s->colorTarget);
         s->colorTarget = Graphics::CreateTexture(colorTargetCreateInfo);
 

--- a/src/bx/framework/systems/renderer.cpp
+++ b/src/bx/framework/systems/renderer.cpp
@@ -365,7 +365,7 @@ void Renderer::Render()
 TextureHandle Renderer::GetEditorCameraColorTarget()
 {
 #ifdef BX_EDITOR_BUILD
-    return Graphics::GetSwapchainColorTarget();
+    return s->colorTarget;// Graphics::GetSwapchainColorTarget();
 #else
     return TextureHandle::null;
 #endif

--- a/src/bx/framework/systems/renderer/id_pass.cpp
+++ b/src/bx/framework/systems/renderer/id_pass.cpp
@@ -12,7 +12,7 @@ const char* ID_PASS_SHADER_SRC = R""""(
 
 layout (location = 0) in vec3 Position;
 
-flat out uvec2 Frag_EntityID;
+layout (location = 0) flat out uvec2 Frag_EntityID;
 
 layout (binding = 0, std140) uniform ConstantBuffer
 {
@@ -35,7 +35,7 @@ void main()
 
 #ifdef FRAGMENT
 
-flat in uvec2 Frag_EntityID;
+layout (location = 0) flat in uvec2 Frag_EntityID;
 
 layout (location = 0) out uvec2 Out_Color;
 

--- a/src/bx/framework/systems/renderer/present_pass.cpp
+++ b/src/bx/framework/systems/renderer/present_pass.cpp
@@ -1,8 +1,10 @@
 #include "bx/framework/systems/renderer/present_pass.hpp"
 
 #include "bx/framework/systems/renderer/lazy_init.hpp"
+#include "bx/framework/resources/shader.hpp"
 
 const char* PRESENT_SHADER_SRC = R""""(
+#include "[assets]/Shaders/Language.shader"
 
 #ifdef VERTEX
 
@@ -10,13 +12,12 @@ layout (location = 0) out vec2 fragTexCoord;
 
 void main()
 {
-	/*vec2 vertices[3]=vec2[3](vec2(-1,-1), vec2(3,-1), vec2(-1, 3));
-	gl_Position = vec4(vertices[gl_VertexID],0,1);
-	fragTexCoord = 0.5 * gl_Position.xy + vec2(0.5);*/
-
     fragTexCoord = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
     gl_Position = vec4(fragTexCoord * 2.0f + -1.0f, 0.0f, 1.0f);
+
+#ifdef VULKAN
     fragTexCoord.y = -fragTexCoord.y;
+#endif
 }
 
 #endif // VERTEX
@@ -71,13 +72,13 @@ struct PresentPipeline : public LazyInit<PresentPipeline, GraphicsPipelineHandle
         ShaderCreateInfo vertexCreateInfo{};
         vertexCreateInfo.name = "Present Vertex Shader";
         vertexCreateInfo.shaderType = ShaderType::VERTEX;
-        vertexCreateInfo.src = PRESENT_SHADER_SRC;
+        vertexCreateInfo.src = ResolveShaderIncludes(PRESENT_SHADER_SRC);
         ShaderHandle vertexShader = Graphics::CreateShader(vertexCreateInfo);
 
         ShaderCreateInfo fragmentCreateInfo{};
         fragmentCreateInfo.name = "Present Fragment Shader";
         fragmentCreateInfo.shaderType = ShaderType::FRAGMENT;
-        fragmentCreateInfo.src = PRESENT_SHADER_SRC;
+        fragmentCreateInfo.src = ResolveShaderIncludes(PRESENT_SHADER_SRC);
         ShaderHandle fragmentShader = Graphics::CreateShader(fragmentCreateInfo);
 
         PipelineLayoutDescriptor pipelineLayoutDescriptor{};

--- a/src/bx/framework/systems/renderer/present_pass.cpp
+++ b/src/bx/framework/systems/renderer/present_pass.cpp
@@ -10,9 +10,13 @@ layout (location = 0) out vec2 fragTexCoord;
 
 void main()
 {
-	vec2 vertices[3]=vec2[3](vec2(-1,-1), vec2(3,-1), vec2(-1, 3));
+	/*vec2 vertices[3]=vec2[3](vec2(-1,-1), vec2(3,-1), vec2(-1, 3));
 	gl_Position = vec4(vertices[gl_VertexID],0,1);
-	fragTexCoord = 0.5 * gl_Position.xy + vec2(0.5);
+	fragTexCoord = 0.5 * gl_Position.xy + vec2(0.5);*/
+
+    fragTexCoord = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(fragTexCoord * 2.0f + -1.0f, 0.0f, 1.0f);
+    fragTexCoord.y = -fragTexCoord.y;
 }
 
 #endif // VERTEX


### PR DESCRIPTION
The long awaited vulkan backend, it has arrived🎉🪅🪅🎊.

Todo before ready for review:
- [x] Shader #define magic to remove `set = x` from opengl compilation (apart from that they compile for both backends, how juicy🤤)
- [x] Visit a bunch of todo's throughout the vulkan backend making it more robust
- [x] Imgui should be able to render scene view in editor mode
- [x] ReadTexture impl to allow object selection in editor
- [x] CI/CD pass

Todo after review:
 - Address vulkan render pass hack (we can discuss during review) to allow descriptors to be updated during recording
 - Explicit sampler support (opengl and vulkan backend use combined samplers atm)
 
 For working game demo, see [Gauntlet fork](https://github.com/JasondeWolff/Gauntlet).