### PR TITLE
🩹 Fix uuid rename

### DIFF
--- a/include/bx/engine/core/ecs.hpp
+++ b/include/bx/engine/core/ecs.hpp
@@ -29,7 +29,7 @@
 #define ECS_MAX_COMPONENTS 64
 #endif
 
-using EntityId = BX::UUID;
+using EntityId = UUID;
 constexpr EntityId INVALID_ENTITY_ID = 0;
 
 class Entity;
@@ -423,7 +423,7 @@ public:
     /// <returns>New valid entity.</returns>
     static Entity CreateEntity()
     {
-        return CreateEntityWithId(BX::GenUuid::MakeUuid());
+        return CreateEntityWithId(GenUUID::MakeUUID());
     }
 
     /// <summary>

--- a/include/bx/engine/core/resource.hpp
+++ b/include/bx/engine/core/resource.hpp
@@ -383,5 +383,5 @@ private:
 
 private:
 	ResourceHandle m_handle = RESOURCE_HANDLE_INVALID;
-	BX::UUID m_uuid;
+	UUID m_uuid;
 };

--- a/include/bx/engine/core/uuid.hpp
+++ b/include/bx/engine/core/uuid.hpp
@@ -2,13 +2,10 @@
 
 #include "bx/engine/core/byte_types.hpp"
 
-namespace BX
+using UUID = u64;
+
+class GenUUID
 {
-	using UUID = u64;
-	
-	class GenUuid
-	{
-	public:
-		static UUID MakeUuid();
-	};
-}
+public:
+	static UUID MakeUUID();
+};

--- a/include/bx/engine/modules/graphics/backend/vulkan/vulkan_api.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/vulkan_api.hpp
@@ -3,31 +3,10 @@
 #define VULKAN_VERSION VK_API_VERSION_1_2
 #define VMA_VULKAN_VERSION 1002000
 
-// TODO: rename platform pc to platform windows?
-#ifdef BX_PLATFORM_PC
-#define VK_USE_PLATFORM_WIN32_KHR
-#elif defined BX_PLATFORM_LINUX
-// TODO
-#endif // BX_PLATFORM_PC
-
 #ifdef BX_WINDOW_GLFW_BACKEND
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
-
-#ifdef BX_PLATFORM_PC
-#define GLFW_EXPOSE_NATIVE_WIN32
-#elif defined BX_PLATFORM_LINUX
-// TODO
-#endif // BX_PLATFORM_PC
-#include <GLFW/glfw3native.h>
 #endif // BX_WINDOW_GLFW_BACKEND
-
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
 
 #include <vulkan/vulkan.hpp>
 #include <vk_mem_alloc.h>

--- a/include/bx/engine/modules/graphics/backend/vulkan/vulkan_native_api.hpp
+++ b/include/bx/engine/modules/graphics/backend/vulkan/vulkan_native_api.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "vulkan_api.hpp"
+
+#ifdef BX_PLATFORM_PC
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+
+#include <vulkan/vulkan_win32.h>
+#elif defined BX_PLATFORM_LINUX
+// TODO
+#endif // BX_PLATFORM_PC
+
+#ifdef BX_WINDOW_GLFW_BACKEND
+#ifdef BX_PLATFORM_PC
+#define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined BX_PLATFORM_LINUX
+// TODO
+#endif // BX_PLATFORM_PC
+#include <GLFW/glfw3native.h>
+#endif // BX_WINDOW_GLFW_BACKEND

--- a/src/bx/engine/core/uuid.cpp
+++ b/src/bx/engine/core/uuid.cpp
@@ -3,19 +3,16 @@
 #include <ctime>
 #include <cstdint>
 
-namespace BX
+UUID GenUUID::MakeUUID()
 {
-    UUID GenUuid::MakeUuid()
-    {
-        // Get current time since epoch in seconds
-        u64 timePart = static_cast<u64>(time(nullptr));
-    
-        // Simple linear congruential generator for random number generation
-        static u64 seed = time(nullptr);
-        seed = (6364136223846793005ULL * seed + 1);
-        u32 randomPart = static_cast<u32>(seed >> 32);
-    
-        // Combine time part and random part to form the UUID
-        return (timePart << 32) | randomPart;
-    }
+    // Get current time since epoch in seconds
+    u64 timePart = static_cast<u64>(time(nullptr));
+
+    // Simple linear congruential generator for random number generation
+    static u64 seed = time(nullptr);
+    seed = (6364136223846793005ULL * seed + 1);
+    u32 randomPart = static_cast<u32>(seed >> 32);
+
+    // Combine time part and random part to form the UUID
+    return (timePart << 32) | randomPart;
 }

--- a/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
+++ b/src/bx/engine/modules/graphics/backend/vulkan/instance.cpp
@@ -6,6 +6,8 @@
 #include "bx/engine/modules/graphics/backend/vulkan/pfn.hpp"
 #include "bx/engine/modules/graphics/backend/vulkan/validation.hpp"
 
+#include "bx/engine/modules/graphics/backend/vulkan/vulkan_native_api.hpp"
+
 #ifdef BX_WINDOW_GLFW_BACKEND
 #define GLFW_INCLUDE_NONE
 #define GLFW_INCLUDE_VULKAN


### PR DESCRIPTION
This PR fixes the previously introduced renaming of the UUID and removes it's namespace (it's in global namespace again). To make compilation work `vulkan_api.hpp` doesn't include all of the required vulkan functionality anymore, only the platform independent stuff. To use platform dependent vulkan calls (mainly used for surface creation) include the `vulkan_native_api.hpp` header.