### PR TITLE
🤠 Multiple wildcard paths

### DIFF
--- a/include/bx/engine/core/file.hpp
+++ b/include/bx/engine/core/file.hpp
@@ -30,7 +30,9 @@ public:
 
 	static bool Exists(const String& path);
 	static u64 LastWrite(const String& filename);
-	static String GetPath(const String& filename);
+	static List<String> GetPath(const String& filename);
+	static String GetExistingPath(const List<String> paths);
+	static String GetExistingOrFirstPath(const List<String> paths);
 
 	static String GetExt(const String& filename);
 	static String RemoveExt(const String& filename);

--- a/include/bx/framework/assets/engine/shaders/Language.shader
+++ b/include/bx/framework/assets/engine/shaders/Language.shader
@@ -1,0 +1,18 @@
+#ifndef LANGUAGE_H
+#define LANGUAGE_H
+
+#define MAX_BINDINGS_PER_SET 32
+
+#ifdef OPENGL
+
+#define BINDING(_set, _binding) binding = _binding
+
+#define gl_VertexIndex gl_VertexID
+
+#elif defined(VULKAN)
+
+#define BINDING(_set, _binding) set = _set, binding = _binding
+
+#endif // VULKAN
+
+#endif // LANGUAGE_H

--- a/src/bx/editor/core/asset_importer.cpp
+++ b/src/bx/editor/core/asset_importer.cpp
@@ -37,7 +37,7 @@ bool AssetImporter::ImportTexture(const String& filename)
     Texture texture;
 
     stbi_set_flip_vertically_on_load(true);
-    auto pData = stbi_load(File::GetPath(filename).c_str(), &texture.width, &texture.height, &texture.channels, 4);
+    auto pData = stbi_load(File::GetExistingPath(File::GetPath(filename)).c_str(), &texture.width, &texture.height, &texture.channels, 4);
     if (pData == nullptr)
         return false;
 
@@ -410,7 +410,7 @@ bool AssetImporter::ImportModel(const String& filename)
     // And have it read the given file with some example postprocessing
     // Usually - if speed is not the most important aspect for you - you'll
     // probably to request more postprocessing than we do in this example.
-    const aiScene* pScene = importer.ReadFile(File::GetPath(filename),
+    const aiScene* pScene = importer.ReadFile(File::GetExistingPath(File::GetPath(filename)),
         aiProcess_CalcTangentSpace |
         aiProcess_Triangulate |
         aiProcess_JoinIdenticalVertices |

--- a/src/bx/editor/views/assets_view.cpp
+++ b/src/bx/editor/views/assets_view.cpp
@@ -521,7 +521,7 @@ void AssetsView::Present(bool& show)
 		if (ImGui::MenuItem("New Folder"))
 		{
 			const auto& node = AssetManager::GetAssetTree().GetNode(g_selectedFolder);
-			File::CreateDirectory(File::GetPath(node.data.path + "/NewFolder"));
+			File::CreateDirectory(File::GetExistingOrFirstPath(File::GetPath(node.data.path + "/NewFolder")));
 		}
 
 		if (ImGui::MenuItem("New Asset"))

--- a/src/bx/editor/views/data_view.cpp
+++ b/src/bx/editor/views/data_view.cpp
@@ -187,7 +187,7 @@ static void InspectTarget(const String& type_name, ImGuiTextFilter& filter, Data
 			ImGui::SameLine();
 
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::Text("%s", File::GetPath(Data::GetFilepath(target)).c_str());
+			ImGui::Text("%s", File::GetExistingPath(File::GetPath(Data::GetFilepath(target))).c_str());
 			ImGui::PopStyleColor();
 		}
 

--- a/src/bx/engine/core/data.cpp
+++ b/src/bx/engine/core/data.cpp
@@ -36,7 +36,7 @@ void Data::Shutdown()
 
 void Data::Save(DataTarget target)
 {
-	auto filepath = File::GetPath(GetFilepath(target));
+	auto filepath = File::GetExistingOrFirstPath(File::GetPath(GetFilepath(target)));
 	std::ofstream ofs(filepath);
 	if (!ofs.is_open())
 		return;
@@ -51,7 +51,7 @@ void Data::Load(DataTarget target)
 	Data::Save(target);
 #endif
 
-	auto filepath = File::GetPath(GetFilepath(target));
+	auto filepath = File::GetExistingPath(File::GetPath(GetFilepath(target)));
 	std::ifstream ifs(filepath);
 	if (!ifs.is_open())
 		return;

--- a/src/bx/engine/core/file.cpp
+++ b/src/bx/engine/core/file.cpp
@@ -30,7 +30,7 @@
 #include <fstream>
 #include <sstream>
 
-HashMap<String, String> s_wildcards;
+HashMap<String, List<String>> s_wildcards;
 
 static List<String> StringSplit(const String& source, const char* delimiter, bool keep_empty)
 {
@@ -60,6 +60,7 @@ void File::Initialize()
 {
 #if defined(BX_PLATFORM_PC) || defined(BX_PLATFORM_LINUX)
 	AddWildcard("[assets]", BX_PROJECT_PATH"/game/assets");
+	AddWildcard("[assets]", BX_PROJECT_PATH"/extern/bx/include/bx/framework/assets");
 	AddWildcard("[settings]", BX_PROJECT_PATH"/game/settings");
 
 	// All platforms
@@ -111,7 +112,7 @@ void File::Initialize()
 
 List<char> File::ReadBinaryFile(const String& filename)
 {
-	const auto path = GetPath(filename);
+	const auto path = GetExistingPath(GetPath(filename));
 	std::ifstream file(path, std::ios::binary | std::ios::ate);
 	if (!file.is_open())
 	{
@@ -132,7 +133,7 @@ List<char> File::ReadBinaryFile(const String& filename)
 
 String File::ReadTextFile(const String& filename)
 {
-	const auto path = GetPath(filename);
+	const auto path = GetExistingPath(GetPath(filename));
 
 	//std::ifstream file(path);
 	//return std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
@@ -158,7 +159,7 @@ String File::ReadTextFile(const String& filename)
 
 bool File::WriteTextFile(const String& filename, const String& text)
 {
-	auto fullpath = GetPath(filename);
+	auto fullpath = GetExistingPath(GetPath(filename));
 	std::ofstream ofs;
 	ofs.open(fullpath);
 
@@ -181,7 +182,16 @@ void File::AddWildcard(const String& wildcard, const String& value)
 			BX_ASSERT(false, "Create directory failed!");
 		}
 	}
-	s_wildcards[wildcard] = value;
+
+	auto wildcardIter = s_wildcards.find(wildcard);
+	if (wildcardIter == s_wildcards.end())
+	{
+		s_wildcards.insert(std::make_pair(wildcard, List<String>{ value }));
+	}
+	else
+	{
+		wildcardIter->second.push_back(value);
+	}
 }
 
 static String StringReplace(
@@ -201,17 +211,73 @@ static String StringReplace(
 	return result;
 }
 
-String File::GetPath(const String& filename)
+List<String> File::GetPath(const String& filename)
 {
-	String filepath = filename;
+	List<String> filepaths{ filename };
 
-	for (const auto& p : s_wildcards)
+	for (const auto& wildcard : s_wildcards)
 	{
-		if (filepath.find(p.first) != String::npos)
-			filepath = StringReplace(filepath, p.first, p.second);
+		List<String> newFilePaths{};
+
+		for (u32 i = 0; i < filepaths.size(); i++)
+		{
+			if (filepaths[i].find(wildcard.first) != String::npos)
+			{
+				for (const auto& p : wildcard.second)
+				{
+					newFilePaths.push_back(StringReplace(filepaths[i], wildcard.first, p));
+				}
+			}
+			else
+			{
+				newFilePaths.push_back(filepaths[i]);
+			}
+		}
+
+		filepaths = newFilePaths;
 	}
 
-	return filepath;
+	return filepaths;
+}
+
+String File::GetExistingPath(const List<String> paths)
+{
+	BX_ASSERT(!paths.empty(), "Cannot get existing path from empty paths.");
+
+	b8 found = false;
+	String existingPath = "";
+
+	for (const auto& path : paths)
+	{
+		struct stat info;
+		b8 exists = (stat(path.c_str(), &info) == 0);
+
+		if (exists)
+		{
+			BX_ASSERT(!found, "Multiple existing paths found.");
+			found = true;
+			existingPath = path;
+		}
+	}
+
+	BX_ASSERT(found, "No existing path found.");
+	return existingPath;
+}
+
+String File::GetExistingOrFirstPath(const List<String> paths)
+{
+	for (const auto& path : paths)
+	{
+		struct stat info;
+		b8 exists = (stat(path.c_str(), &info) == 0);
+
+		if (exists)
+		{
+			return path;
+		}
+	}
+
+	return paths[0];
 }
 
 String File::GetExt(const String& filename)
@@ -226,12 +292,13 @@ String File::RemoveExt(const String& filename)
 
 bool File::Move(const String& oldPath, const String& newPath)
 {
-	String oldFullPath = File::GetPath(oldPath);
-	String newFullPath = File::GetPath(newPath);
+	String oldFullPath = GetExistingPath(File::GetPath(oldPath));
+	List<String> newFullPaths = File::GetPath(newPath);
+	BX_ASSERT(newFullPaths.size() == 1, "More than 1 possible new paths found to move to.");
 
 #if defined(BX_PLATFORM_PC)
 	LPCSTR oldFileName = oldFullPath.c_str();
-	LPCSTR newFileName = newFullPath.c_str();
+	LPCSTR newFileName = newFullPaths[0].c_str();
 
 	// Attempt to move the file with additional options
 	if (MoveFileEx(oldFileName, newFileName, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING))
@@ -257,7 +324,7 @@ bool File::Move(const String& oldPath, const String& newPath)
 bool File::Delete(const String& filename)
 {
 #if defined(BX_PLATFORM_PC)
-	const String fullpath = GetPath(filename);
+	const String fullpath = GetExistingPath(GetPath(filename));
 	
 	DWORD attributes = GetFileAttributes(fullpath.c_str());
 	if (attributes == INVALID_FILE_ATTRIBUTES)
@@ -298,7 +365,7 @@ bool File::Delete(const String& filename)
 
 bool File::Exists(const String& path)
 {
-	const auto filepath = GetPath(path);
+	const auto filepath = GetExistingPath(GetPath(path));
 	struct stat info;
 	return (stat(filepath.c_str(), &info) == 0);
 }
@@ -351,7 +418,7 @@ bool File::ListFiles(const String& root, List<FileHandle>& files)
 {
 #if defined(BX_PLATFORM_PC)
 
-	String rootPath = GetPath(root);
+	String rootPath = GetExistingOrFirstPath(GetPath(root));
 
 	if (rootPath.size() > (MAX_PATH - 3))
 		return false;

--- a/src/bx/engine/modules/imgui.cpp
+++ b/src/bx/engine/modules/imgui.cpp
@@ -106,7 +106,7 @@ bool ImGuiImpl::Initialize()
     //io.Fonts->AddFontFromFileTTF(fontpath.c_str(), iconSize * UIScale, &config, icons_ranges);
 
 #ifdef BX_EDITOR_BUILD
-    const String iniPath = File::GetPath("[editor]/imgui.ini");
+    const String iniPath = File::GetExistingOrFirstPath(File::GetPath("[editor]/imgui.ini"));
     const char* constStr = iniPath.c_str();
     const SizeType pathSize = iniPath.size() + 1;
     char* str = new char[pathSize];

--- a/src/bx/framework/gameobject.cpp
+++ b/src/bx/framework/gameobject.cpp
@@ -49,7 +49,7 @@ GameObjectData GameObjectData::Load(const String& filepath)
 {
 	GameObjectData gameObjData;
 
-	std::ifstream stream(File::GetPath(filepath));
+	std::ifstream stream(File::GetExistingPath(File::GetPath(filepath)));
 	cereal::JSONInputArchive ar(stream);
 	ar(cereal::make_nvp("gameobject", gameObjData));
 
@@ -58,7 +58,7 @@ GameObjectData GameObjectData::Load(const String& filepath)
 
 void GameObjectData::Save(const String& filepath, const GameObjectData& data)
 {
-	std::ofstream stream(File::GetPath(filepath));
+	std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filepath)));
 	cereal::JSONOutputArchive ar(stream);
 	ar(cereal::make_nvp("gameobject", data));
 }
@@ -260,7 +260,7 @@ void Scene::Load(Scene& scene, const String& filename)
 
 	try
 	{
-		std::ifstream stream(File::GetPath(filename));
+		std::ifstream stream(File::GetExistingPath(File::GetPath(filename)));
 		cereal::JSONInputArchive ar(stream);
 		ar(cereal::make_nvp("scene", scene));
 	}
@@ -274,7 +274,7 @@ void Scene::Save(const Scene& scene, const String& filename)
 {
 	try
 	{
-		std::ofstream stream(File::GetPath(filename));
+		std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)));
 		cereal::JSONOutputArchive ar(stream);
 		ar(cereal::make_nvp("scene", scene));
 	}

--- a/src/bx/framework/resources/animation.cpp
+++ b/src/bx/framework/resources/animation.cpp
@@ -15,7 +15,7 @@ template<>
 bool Resource<Animation>::Save(const String& filename, const Animation& data)
 {
     // Serialize data
-    std::ofstream stream(File::GetPath(filename), std::ios::binary);
+    std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 
@@ -29,7 +29,7 @@ template<>
 bool Resource<Animation>::Load(const String& filename, Animation& data)
 {
     // Deserialize data
-    std::ifstream stream(File::GetPath(filename), std::ios::binary);
+    std::ifstream stream(File::GetExistingPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 

--- a/src/bx/framework/resources/material.cpp
+++ b/src/bx/framework/resources/material.cpp
@@ -14,7 +14,7 @@ template<>
 bool Resource<Material>::Save(const String& filename, const Material& data)
 {
     // Serialize data
-    std::ofstream stream(File::GetPath(filename));
+    std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)));
     if (stream.fail())
         return false;
 
@@ -28,7 +28,7 @@ template<>
 bool Resource<Material>::Load(const String& filename, Material& data)
 {
     // Deserialize data
-    std::ifstream stream(File::GetPath(filename));
+    std::ifstream stream(File::GetExistingPath(File::GetPath(filename)));
     if (stream.fail())
         return false;
 

--- a/src/bx/framework/resources/mesh.cpp
+++ b/src/bx/framework/resources/mesh.cpp
@@ -16,7 +16,7 @@ bool Resource<Mesh>::Save(const String& filename, const Mesh& data)
     // TODO: Use some sort of compression (research needs to be done)
 
     // Serialize data
-    std::ofstream stream(File::GetPath(filename), std::ios::binary);
+    std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 
@@ -30,7 +30,7 @@ template<>
 bool Resource<Mesh>::Load(const String& filename, Mesh& data)
 {
     // Deserialize data
-    std::ifstream stream(File::GetPath(filename), std::ios::binary);
+    std::ifstream stream(File::GetExistingPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 

--- a/src/bx/framework/resources/shader.cpp
+++ b/src/bx/framework/resources/shader.cpp
@@ -59,7 +59,7 @@ String ResolveShaderIncludes(const String& source)
 template<>
 bool Resource<Shader>::Save(const String& filename, const Shader& data)
 {
-    std::ofstream stream(File::GetPath(filename));
+    std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)));
     if (stream.fail())
         return false;
 
@@ -72,7 +72,7 @@ bool Resource<Shader>::Save(const String& filename, const Shader& data)
 template<>
 bool Resource<Shader>::Load(const String& filename, Shader& data)
 {
-    std::ifstream stream(File::GetPath(filename));
+    std::ifstream stream(File::GetExistingPath(File::GetPath(filename)));
     if (stream.fail() || !stream.good())
         return false;
     std::stringstream ss;

--- a/src/bx/framework/resources/skeleton.cpp
+++ b/src/bx/framework/resources/skeleton.cpp
@@ -14,7 +14,7 @@ template<>
 bool Resource<Skeleton>::Save(const String& filename, const Skeleton& data)
 {
     // Serialize data
-    std::ofstream stream(File::GetPath(filename), std::ios::binary);
+    std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 
@@ -28,7 +28,7 @@ template<>
 bool Resource<Skeleton>::Load(const String& filename, Skeleton& data)
 {
     // Deserialize data
-    std::ifstream stream(File::GetPath(filename), std::ios::binary);
+    std::ifstream stream(File::GetExistingPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 

--- a/src/bx/framework/resources/texture.cpp
+++ b/src/bx/framework/resources/texture.cpp
@@ -18,7 +18,7 @@ bool Resource<Texture>::Save(const String& filename, const Texture& data)
     // @Conor, I propose we use bc encoding as it has a wider range of supported devices
     // On top of that, bc7 performs a bit better
 
-    std::ofstream stream(File::GetPath(filename), std::ios::binary);
+    std::ofstream stream(File::GetExistingOrFirstPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 
@@ -32,7 +32,7 @@ template<>
 bool Resource<Texture>::Load(const String& filename, Texture& data)
 {
     // Deserialize data
-    std::ifstream stream(File::GetPath(filename), std::ios::binary);
+    std::ifstream stream(File::GetExistingPath(File::GetPath(filename)), std::ios::binary);
     if (stream.fail())
         return false;
 

--- a/src/bx/framework/systems/renderer/present_pass.cpp
+++ b/src/bx/framework/systems/renderer/present_pass.cpp
@@ -4,7 +4,7 @@
 #include "bx/framework/resources/shader.hpp"
 
 const char* PRESENT_SHADER_SRC = R""""(
-#include "[assets]/Shaders/Language.shader"
+#include "[assets]/engine/shaders/Language.shader"
 
 #ifdef VERTEX
 


### PR DESCRIPTION
This PR adds support for multiple wildcards. When loading a file, `File::GetExistingPath` can be used to find the actual existing path, as `File::GetPath` now returns a list of all possible wild card combinations.

Example:
`[assets]` = `"gameAssets", "engineAssets"`
`[buildConfig]` = `"dev", "shipping"`

then a call with `File::GetPath("[assets]/[buildConfig]/mesh.gltf")` will return a list of:
 - "gameAssets/dev/mesh.gltf"
 - "gameAssets/shipping/mesh.gltf"
 - "engineAssets/dev/mesh.gltf"
 - "engineAssets/shipping/mesh.gltf"
 
When saving things become a bit more tricky, as there might not already be a file in that location, and we suddenly have multiple "valid" paths to save to. In that case the `File::GetExistingOrFirstPath` can be used. It loops over all the paths and returns the first existing one (allowing to overwrite an existing file during a save operation for example). However, if none of the paths are valid, it will simply return the first path.

The first path is ALWAYS deterministic based on the order of which the wildcards are registered. At the moment the game assets are registered as a wildcard BEFORE the engine assets, so saving a file will always save into the game assets path, UNLESS the file doesn't exist on the game assets yet but DOES exist on the engine assets.